### PR TITLE
Add wrapperless blocks, hook shims and a block support

### DIFF
--- a/src/block.json
+++ b/src/block.json
@@ -15,6 +15,9 @@
     }
   },
   "supports": {
+    "color": {
+      "text": true
+    },
     "html": true
   },
   "textdomain": "block-hydration-experiments",

--- a/src/framework/save.js
+++ b/src/framework/save.js
@@ -1,18 +1,21 @@
 import { name } from "../block.json";
 import { useBlockProps, InnerBlocks } from "@wordpress/block-editor";
 
-const save = (Comp) => ({ attributes }) => (
-  <div
-    is={name.replace("/", "_")}
-    {...useBlockProps.save()}
-    data-gutenberg-attributes={JSON.stringify(attributes)}
-  >
-    <Comp attributes={attributes}>
-      <gutenberg-inner-blocks>
-        <InnerBlocks.Content />
-      </gutenberg-inner-blocks>
-    </Comp>
-  </div>
-);
+const save = (Comp) => ({ attributes }) => {
+  const blockProps = useBlockProps.save();
+  return (
+    <gutenberg-interactive-block
+      data-gutenberg-block-type={name}
+      data-gutenberg-attributes={JSON.stringify(attributes)}
+      data-gutenberg-block-props={JSON.stringify(blockProps)}
+    >
+      <Comp blockProps={blockProps} attributes={attributes}>
+        <gutenberg-inner-blocks>
+          <InnerBlocks.Content />
+        </gutenberg-inner-blocks>
+      </Comp>
+    </gutenberg-interactive-block>
+  );
+};
 
 export default save;

--- a/src/framework/view.js
+++ b/src/framework/view.js
@@ -1,4 +1,10 @@
-import { hydrate } from "react-dom";
+import { hydrate } from "./wordpress-element";
+
+const blockTypes = new Map();
+
+export default function view(name, Comp) {
+  blockTypes.set(name, Comp);
+}
 
 const Children = ({ value }) => {
   if (!value) return null;
@@ -11,32 +17,33 @@ const Children = ({ value }) => {
 };
 Children.shouldComponentUpdate = () => false;
 
-const view = (name, Comp) => {
-  customElements.define(
-    name.replace("/", "_"),
-    class extends HTMLDivElement {
-      connectedCallback() {
-        setTimeout(() => {
-          const attributes = JSON.parse(this.dataset["gutenbergAttributes"]);
-          const innerBlocks = this.querySelector("gutenberg-inner-blocks");
-          hydrate(
-            <Comp
-              isView={true}
-              attributes={attributes}
-              suppressHydrationWarning={true}
-            >
-              <Children
-                value={innerBlocks && innerBlocks.innerHTML}
-                suppressHydrationWarning={true}
-              />
-            </Comp>,
-            this
-          );
-        });
-      }
-    },
-    { extends: "div" }
-  );
-};
+class GutenbergBlock extends HTMLElement {
+  connectedCallback() {
+    setTimeout(() => {
+      const blockType = this.getAttribute("data-gutenberg-block-type");
+      const attributes = JSON.parse(
+        this.getAttribute("data-gutenberg-attributes")
+      );
+      const blockProps = JSON.parse(
+        this.getAttribute("data-gutenberg-block-props")
+      );
+      const innerBlocks = this.querySelector("gutenberg-inner-blocks");
+      const Comp = blockTypes.get(blockType);
+      hydrate(
+        <Comp
+          attributes={attributes}
+          blockProps={blockProps}
+          suppressHydrationWarning={true}
+        >
+          <Children
+            value={innerBlocks && innerBlocks.innerHTML}
+            suppressHydrationWarning={true}
+          />
+        </Comp>,
+        this
+      );
+    });
+  }
+}
 
-export default view;
+customElements.define("gutenberg-interactive-block", GutenbergBlock);

--- a/src/framework/wordpress-element.js
+++ b/src/framework/wordpress-element.js
@@ -1,0 +1,14 @@
+import {
+  useState as useReactState,
+  useEffect as useReactEffect,
+} from "@wordpress/element";
+export { hydrate } from "react-dom";
+
+// Dirty dirty trick
+export const isView = !window.wp.blockEditor;
+
+const noop = () => {};
+
+export const useState = (init) => (isView ? useReactState(init) : [init, noop]);
+
+export const useEffect = (...args) => (isView ? useReactEffect(...args) : noop);

--- a/src/frontend/block.js
+++ b/src/frontend/block.js
@@ -1,18 +1,18 @@
-import { useState } from "@wordpress/element";
+import { useState } from "../framework/wordpress-element";
 import Title from "./title";
 import Button from "./button";
 
-const Block = ({ attributes, children, isView }) => {
-  const [show, setShow] = isView ? useState(true) : [true];
-  const [counter, setCounter] = isView ? useState(0) : [0];
+const Block = ({ blockProps, attributes, children }) => {
+  const [show, setShow] = useState(true);
+  const [counter, setCounter] = useState(0);
 
   return (
-    <>
+    <div {...blockProps}>
       <Title message={attributes.message} />
       <Button handler={() => setShow(!show)} />
       <button onClick={() => setCounter(counter + 1)}>{counter}</button>
       {show && children}
-    </>
+    </div>
   );
 };
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -2,3 +2,8 @@
   padding: 15px 10px 15px 50px;
   background-color: rgb(238, 237, 237);
 }
+
+gutenberg-block,
+gutenberg-inner-blocks {
+  display: contents;
+}


### PR DESCRIPTION
Continuing the tests here, I've added support for:

- Wrapperless hydration: now, the `Block` component can control the wrapper `div` as well.
- Hook shims: I've added support for `useState` and `useEffect` in `Block` using @fabiankaegy's trick. This will need to replace replaced with something natively supported by Gutenberg. I'd like to take a look at the [custom serializer](https://github.com/WordPress/gutenberg/blob/trunk/packages/element/src/serialize.js) with @gziolo.
- Block supports (only in the wrapper node, no skip-serialization): I'm serializing the block props (which include the `has-text-color`... class names) because I thought React would remove them, but it doesn't seem to do so. I need to investigate more.

The block now hides/shows the children to test that it can destroy and recreate them while preserving hydration correctly.