### PR TITLE
Implement different hydration techniques

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,10 +43,10 @@ Feel free to inspect the code, open issues, submit PRs, ask questions...
 - [ ] Avoid bundling unnecessary code (like the Save serializer or lodash) in the Frontend.
 - [ ] Pattern to export different code depending on the context (Edit, Save, or Frontend).
 - [ ] Bundle Preact (compat) instead of React in the Frontend (up for discussion).
-- [ ] Implement different hydration techniques:
-  - [ ] Load
-  - [ ] Idle
-  - [ ] View
-  - [ ] Media
+- [x] Implement different hydration techniques:https://github.com/luisherranz/block-hydration-experiments/pull/14.
+  - [x] Load
+  - [x] Idle
+  - [x] View
+  - [x] Media
 - [ ] Change hydration technique based on block attributes.
 - [ ] Experiment ways to not hydrate the entire block, only the "client components".

--- a/src/gutenberg-packages/frontend.js
+++ b/src/gutenberg-packages/frontend.js
@@ -29,7 +29,7 @@ class GutenbergBlock extends HTMLElement {
       );
       const innerBlocks = this.querySelector("gutenberg-inner-blocks");
       const Comp = blockTypes.get(blockType);
-      const technique = this.getAttribute("data-gutenberg-hydrate");
+      const hydrationTechnique = this.getAttribute("data-gutenberg-hydrate");
 
       hydrate(
         <EnvContext.Provider value="frontend">
@@ -45,7 +45,7 @@ class GutenbergBlock extends HTMLElement {
           </Comp>
         </EnvContext.Provider>,
         this,
-        technique
+        hydrationTechnique
       );
     });
   }

--- a/src/gutenberg-packages/frontend.js
+++ b/src/gutenberg-packages/frontend.js
@@ -22,13 +22,15 @@ class GutenbergBlock extends HTMLElement {
     setTimeout(() => {
       const blockType = this.getAttribute("data-gutenberg-block-type");
       const attributes = JSON.parse(
-        this.getAttribute("data-gutenberg-attributes"),
+        this.getAttribute("data-gutenberg-attributes")
       );
       const blockProps = JSON.parse(
-        this.getAttribute("data-gutenberg-block-props"),
+        this.getAttribute("data-gutenberg-block-props")
       );
       const innerBlocks = this.querySelector("gutenberg-inner-blocks");
       const Comp = blockTypes.get(blockType);
+      const technique = this.getAttribute("data-gutenberg-hydrate");
+
       hydrate(
         <EnvContext.Provider value="frontend">
           <Comp
@@ -43,6 +45,7 @@ class GutenbergBlock extends HTMLElement {
           </Comp>
         </EnvContext.Provider>,
         this,
+        technique
       );
     });
   }

--- a/src/gutenberg-packages/frontend.js
+++ b/src/gutenberg-packages/frontend.js
@@ -29,8 +29,12 @@ class GutenbergBlock extends HTMLElement {
       );
       const innerBlocks = this.querySelector("gutenberg-inner-blocks");
       const Comp = blockTypes.get(blockType);
-      const hydrationTechnique = this.getAttribute("data-gutenberg-hydrate");
-
+      const technique = this.getAttribute("data-gutenberg-hydrate");
+      const media = this.getAttribute("data-gutenberg-media");
+      const hydrationOptions = {
+        technique,
+        media,
+      };
       hydrate(
         <EnvContext.Provider value="frontend">
           <Comp
@@ -45,7 +49,7 @@ class GutenbergBlock extends HTMLElement {
           </Comp>
         </EnvContext.Provider>,
         this,
-        hydrationTechnique
+        hydrationOptions
       );
     });
   }

--- a/src/gutenberg-packages/wordpress-blocks.js
+++ b/src/gutenberg-packages/wordpress-blocks.js
@@ -1,7 +1,8 @@
 import { InnerBlocks, useBlockProps } from "@wordpress/block-editor";
 import { registerBlockType as gutenbergRegisterBlockType } from "@wordpress/blocks";
 
-const save = (name, Comp) =>
+const save =
+  (name, Comp) =>
   ({ attributes }) => {
     const blockProps = useBlockProps.save();
     return (
@@ -9,6 +10,7 @@ const save = (name, Comp) =>
         data-gutenberg-block-type={name}
         data-gutenberg-attributes={JSON.stringify(attributes)}
         data-gutenberg-block-props={JSON.stringify(blockProps)}
+        data-gutenberg-hydrate="view"
       >
         <Comp blockProps={blockProps} attributes={attributes}>
           <gutenberg-inner-blocks>

--- a/src/gutenberg-packages/wordpress-blocks.js
+++ b/src/gutenberg-packages/wordpress-blocks.js
@@ -10,7 +10,7 @@ const save =
         data-gutenberg-block-type={name}
         data-gutenberg-attributes={JSON.stringify(attributes)}
         data-gutenberg-block-props={JSON.stringify(blockProps)}
-        data-gutenberg-hydrate="view"
+        data-gutenberg-hydrate="idle"
       >
         <Comp blockProps={blockProps} attributes={attributes}>
           <gutenberg-inner-blocks>

--- a/src/gutenberg-packages/wordpress-element.js
+++ b/src/gutenberg-packages/wordpress-element.js
@@ -37,6 +37,8 @@ export const useEffect = (...args) =>
 
 export const hydrate = (container, element, technique) => {
   switch (technique) {
+    // Hydrate the element when is visible in the viewport.
+    // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
     case "view":
       const io = new IntersectionObserver((entries) => {
         for (const entry of entries) {
@@ -50,8 +52,11 @@ export const hydrate = (container, element, technique) => {
       io.observe(element.children[0]);
       break;
     case "idle":
+      // Safari does not support requestIdleCalback, we use a timeout instead. https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback
       if ("requestIdleCallback" in window) {
-        window.requestIdleCallback(() => ReactHydrate(container, element));
+        window.requestIdleCallback(() => {
+          ReactHydrate(container, element);
+        });
       } else {
         setTimeout(ReactHydrate(container, element), 200);
       }


### PR DESCRIPTION
Fixes #12 

I added an initial approach to the different hydration techniques as Astro (copy-pasted from the issue and Astro's codebase, mainly).

Should be the technique a prop in block.json rather than an attribute? (I guess choosing the hydration technique on the editor is an overkill)

Should we allow the Block developer to choose the hydration technique or is it a complex concept for most developers? (I still have to check some docs about IntersectionObserver and RequestIdleCallback)

