### PR TITLE
Update dprint: fix spaces on functions with zero arguments

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -20,7 +20,7 @@
 		"spaceAround": true
 	},
 	"plugins": [
-		"https://plugins.dprint.dev/typescript-0.68.2.wasm",
+		"https://plugins.dprint.dev/typescript-0.68.3.wasm",
 		"https://plugins.dprint.dev/json-0.15.2.wasm",
 		"https://plugins.dprint.dev/markdown-0.13.2.wasm"
 	]

--- a/src/gutenberg-packages/wordpress-blockeditor.js
+++ b/src/gutenberg-packages/wordpress-blockeditor.js
@@ -1,7 +1,7 @@
 import { useBlockEnvironment } from './wordpress-element';
 
 export const RichText = ( { tagName: Tag, children, ...props } ) => {
-	return useBlockEnvironment(  ) === 'edit' ?
+	return useBlockEnvironment() === 'edit' ?
 		(
 			<window.wp.blockEditor.RichText
 				value={children}

--- a/src/gutenberg-packages/wordpress-element.js
+++ b/src/gutenberg-packages/wordpress-element.js
@@ -32,10 +32,10 @@ export const useBlockEnvironment = () => {
 const noop = () => {};
 
 export const useState = ( init ) =>
-	useBlockEnvironment(  ) !== 'save' ? useReactState( init ) : [ init, noop ];
+	useBlockEnvironment() !== 'save' ? useReactState( init ) : [ init, noop ];
 
 export const useEffect = ( ...args ) =>
-	useBlockEnvironment(  ) !== 'save' ? useReactEffect( ...args ) : noop;
+	useBlockEnvironment() !== 'save' ? useReactEffect( ...args ) : noop;
 
 export const hydrate = ( element, container, hydrationOptions ) => {
 	const { technique, media } = hydrationOptions || {};


### PR DESCRIPTION
This is just because this PR has been merged: https://github.com/dprint/dprint-plugin-typescript/pull/368