### PR TITLE
Update authors to WP team

### DIFF
--- a/block-hydration-experiments.php
+++ b/block-hydration-experiments.php
@@ -4,7 +4,7 @@
  * Version:           0.1.0
  * Requires at least: 5.9
  * Requires PHP:      7.0
- * Author:            Luis Herranz
+ * Author:            Gutenberg Team
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       block-hydration-experiments

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "block-hydration-experiments",
 	"version": "0.1.0",
-	"author": "Luis Herranz",
+	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {


### PR DESCRIPTION
### What

As the repo has been moved to the WordPress Github organization, we may have to update the PHP plugin and package.json to be similar to Gutenberg repo.