### PR TITLE
Change repo URL and rename block

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ Feel free to inspect the code, open issues, submit PRs, ask questions...
 
 ## Current Status
 
-[You can see a video with the explanation of the current status on this issue.](https://github.com/luisherranz/block-hydration-experiments/issues/6)
+[You can see a video with the explanation of the current status on this issue.](https://github.com/WordPress/block-hydration-experiments/issues/6)
 
 ## Current Experiments
 
@@ -29,17 +29,17 @@ Feel free to inspect the code, open issues, submit PRs, ask questions...
 - [x] Support partial hydration with Inner blocks (children raw HTML).
 - [x] Use children instead of in Save component to be able to reuse the same component in the Frontend.
 - [x] Serialize attributes and pass them down to the Frontend component.
-- [x] Support initially hidden Inner blocks – [PR](https://github.com/luisherranz/block-hydration-experiments/pull/8)
-- [x] Support definition of public frontend attributes and only serialize those – [PR](https://github.com/luisherranz/block-hydration-experiments/pull/15)
-- [x] Wrapperless hydration – [PR](https://github.com/luisherranz/block-hydration-experiments/pull/3)
-- [x] Reuse the same RichText component across the different environments (Edit, Save, and Frontend) – [PR](https://github.com/luisherranz/block-hydration-experiments/pull/2)
-- [x] Support useState and useEffect hook in the Save component to be able to reuse the same component in the Frontend – [PR](https://github.com/luisherranz/block-hydration-experiments/pull/3)
-- [x] Implement different hydration techniques: Idle, View, Media – [PR](https://github.com/luisherranz/block-hydration-experiments/pull/14)
+- [x] Support initially hidden Inner blocks – [PR](https://github.com/WordPress/block-hydration-experiments/pull/8)
+- [x] Support definition of public frontend attributes and only serialize those – [PR](https://github.com/WordPress/block-hydration-experiments/pull/15)
+- [x] Wrapperless hydration – [PR](https://github.com/WordPress/block-hydration-experiments/pull/3)
+- [x] Reuse the same RichText component across the different environments (Edit, Save, and Frontend) – [PR](https://github.com/WordPress/block-hydration-experiments/pull/2)
+- [x] Support useState and useEffect hook in the Save component to be able to reuse the same component in the Frontend – [PR](https://github.com/WordPress/block-hydration-experiments/pull/3)
+- [x] Implement different hydration techniques: Idle, View, Media – [PR](https://github.com/WordPress/block-hydration-experiments/pull/14)
 
 ### Up next
 
-- [ ] Support for Block Supports (wrapper only) – [PR in progress](https://github.com/luisherranz/block-hydration-experiments/pull/3)
-- [ ] Support the BlockContext between different blocks – [PR in progress](https://github.com/luisherranz/block-hydration-experiments/pull/7)
+- [ ] Support for Block Supports (wrapper only) – [PR in progress](https://github.com/WordPress/block-hydration-experiments/pull/3)
+- [ ] Support the BlockContext between different blocks – [PR in progress](https://github.com/WordPress/block-hydration-experiments/pull/7)
 - [ ] Support “static” (not hydrated) BlockContext parents
 - [ ] Support for the Context API between different blocks.
 - [ ] Support attribute sourcing.

--- a/src/block.json
+++ b/src/block.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
-	"name": "luisherranz/block-hydration-experiments",
+	"name": "bhe/block-hydration-experiments",
 	"version": "0.1.0",
 	"title": "Block Hydration Experiments",
 	"category": "text",

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import Frontend from './frontend';
 import { registerBlockType } from './gutenberg-packages/wordpress-blocks';
 import './style.scss';
 
-registerBlockType( 'luisherranz/block-hydration-experiments', {
+registerBlockType( 'bhe/block-hydration-experiments', {
 	edit: Edit,
 	// The Save component is derived from the Frontend component.
 	frontend: Frontend,

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,4 +1,4 @@
-.wp-block-luisherranz-block-hydration-experiments {
+.wp-block-bhe-block-hydration-experiments {
   padding: 15px 10px 15px 50px;
   background-color: rgb(238, 237, 237);
 }

--- a/src/view.js
+++ b/src/view.js
@@ -1,4 +1,4 @@
 import Frontend from './frontend';
 import { registerBlockType } from './gutenberg-packages/frontend';
 
-registerBlockType( 'luisherranz/block-hydration-experiments', Frontend );
+registerBlockType( 'bhe/block-hydration-experiments', Frontend );


### PR DESCRIPTION
Following up with https://github.com/WordPress/block-hydration-experiments/pull/24, rename also the block and the links to the repo.