### PR TITLE
fix rendering of applied rich text formats in proxy component

### DIFF
--- a/src/gutenberg-packages/wordpress-blockeditor.js
+++ b/src/gutenberg-packages/wordpress-blockeditor.js
@@ -10,5 +10,5 @@ export const RichText = ( { tagName: Tag, children, ...props } ) => {
 				{...props}
 			/>
 		) :
-		<Tag {...props}>{children}</Tag>;
+		<Tag {...props} dangerouslySetInnerHTML={{ __html: children }} />;
 };


### PR DESCRIPTION
The value that gets passed into the `RichText`component is a text string that may include actual markup in cases where rich text formats like bold / italics etc are applied to the string. In order for them to render correctly, we need to set the text as inner HTML.