### PR TITLE
Rename duplicated register block type frontend function

### DIFF
--- a/src/blocks/interactive-child/frontend.js
+++ b/src/blocks/interactive-child/frontend.js
@@ -1,8 +1,8 @@
 import CounterContext from '../../context/counter';
 import ThemeContext from '../../context/theme';
-import { registerBlockType } from '../../gutenberg-packages/frontend';
+import { registerBlockTypeFrontend } from '../../gutenberg-packages/frontend';
 import View from './view';
 
-registerBlockType('bhe/interactive-child', View, {
+registerBlockTypeFrontend('bhe/interactive-child', View, {
 	usesContext: [ThemeContext, CounterContext],
 });

--- a/src/blocks/interactive-parent/frontend.js
+++ b/src/blocks/interactive-parent/frontend.js
@@ -1,8 +1,8 @@
 import CounterContext from '../../context/counter';
 import ThemeContext from '../../context/theme';
-import { registerBlockType } from '../../gutenberg-packages/frontend';
+import { registerBlockTypeFrontend } from '../../gutenberg-packages/frontend';
 import View from './view';
 
-registerBlockType('bhe/interactive-parent', View, {
+registerBlockTypeFrontend('bhe/interactive-parent', View, {
 	providesContext: [ThemeContext, CounterContext],
 });

--- a/src/gutenberg-packages/frontend.js
+++ b/src/gutenberg-packages/frontend.js
@@ -5,7 +5,7 @@ import { unmountComponentAtNode } from 'react-dom';
 
 const blockTypes = createGlobal('wpBlockTypes', new Map());
 
-export const registerBlockType = (name, Component, options) => {
+export const registerBlockTypeFrontend = (name, Component, options) => {
 	blockTypes.set(name, { Component, options });
 };
 


### PR DESCRIPTION
Fixes #55 

Right now, we are using the same name for two different functions that do different things, this may cause understanding errors.

[In wordpress-blocks.js file](https://github.com/WordPress/block-hydration-experiments/blob/2d8a9ff55314e6f96a23aac535f1a91c944da213/src/gutenberg-packages/wordpress-blocks.js#L21):
```
export const registerBlockType = (name, { edit, view, ...rest }) => {
	gutenbergRegisterBlockType(name, {
		edit,
		save: Wrapper(view),
		...rest,
	});
};
```

[In gutenberg-packages/frontend.js file](https://github.com/WordPress/block-hydration-experiments/blob/2d8a9ff55314e6f96a23aac535f1a91c944da213/src/gutenberg-packages/frontend.js#L8)
```
export const registerBlockType = (name, Component, options) => {
	blockTypes.set(name, { Component, options });
};
```

After a little chat, we think that add the suffix Frontend will make things easier.