### PR TITLE
⚛️ Add `Suspense` and `ErrorBoundary` examples

### DIFF
--- a/src/blocks/interactive-child/lazy-paragraph.js
+++ b/src/blocks/interactive-child/lazy-paragraph.js
@@ -1,1 +1,0 @@
-export default ({ children }) => <p>Lazy-loaded content: {children}</p>

--- a/src/blocks/interactive-child/lazy-paragraph.js
+++ b/src/blocks/interactive-child/lazy-paragraph.js
@@ -1,0 +1,1 @@
+export default ({ children }) => <p>Lazy-loaded content: {children}</p>

--- a/src/blocks/interactive-child/view.js
+++ b/src/blocks/interactive-child/view.js
@@ -1,13 +1,18 @@
 import CounterContext from '../../context/counter';
 import ThemeContext from '../../context/theme';
-import { useContext } from '../../gutenberg-packages/wordpress-element';
+import { useContext, useState } from '../../gutenberg-packages/wordpress-element';
 
 const View = ({ blockProps, context }) => {
 	const theme = useContext(ThemeContext);
 	const counter = useContext(CounterContext);
 
+	const [shouldThrow, setShouldThrow] = useState(false);
+
+	if (shouldThrow) throw Error('Interactive Child: block broken');
+
 	return (
 		<div {...blockProps}>
+			<button onClick={() => setShouldThrow(true)}>Throw error</button>
 			<p>
 				Block Context from interactive parent - "bhe/interactive-title":{' '}
 				{context['bhe/interactive-title']}

--- a/src/blocks/interactive-child/view.js
+++ b/src/blocks/interactive-child/view.js
@@ -1,13 +1,6 @@
 import CounterContext from '../../context/counter';
 import ThemeContext from '../../context/theme';
-import {
-	useContext,
-	useState,
-	Suspense,
-	lazy,
-} from '../../gutenberg-packages/wordpress-element';
-
-const LazyParagraph = lazy(() => import('./lazy-paragraph'));
+import { useContext, useState } from '../../gutenberg-packages/wordpress-element';
 
 const View = ({ blockProps, context }) => {
 	const theme = useContext(ThemeContext);
@@ -32,17 +25,6 @@ const View = ({ blockProps, context }) => {
 			<div className="animation"></div>
 			<p>React Context - "counter": {counter}</p>
 			<p>React Context - "theme": {theme}</p>
-			<Suspense
-				fallback={
-					<p key="suspense">
-						<div>Loading...</div>
-					</p>
-				}
-			>
-				<div key="suspense">
-					<LazyParagraph>Hello!</LazyParagraph>
-				</div>
-			</Suspense>
 		</div>
 	);
 };

--- a/src/blocks/interactive-child/view.js
+++ b/src/blocks/interactive-child/view.js
@@ -1,6 +1,13 @@
 import CounterContext from '../../context/counter';
 import ThemeContext from '../../context/theme';
-import { useContext, useState } from '../../gutenberg-packages/wordpress-element';
+import {
+	useContext,
+	useState,
+	Suspense,
+	lazy,
+} from '../../gutenberg-packages/wordpress-element';
+
+const LazyParagraph = lazy(() => import('./lazy-paragraph'));
 
 const View = ({ blockProps, context }) => {
 	const theme = useContext(ThemeContext);
@@ -25,6 +32,17 @@ const View = ({ blockProps, context }) => {
 			<div className="animation"></div>
 			<p>React Context - "counter": {counter}</p>
 			<p>React Context - "theme": {theme}</p>
+			<Suspense
+				fallback={
+					<p key="suspense">
+						<div>Loading...</div>
+					</p>
+				}
+			>
+				<div key="suspense">
+					<LazyParagraph>Hello!</LazyParagraph>
+				</div>
+			</Suspense>
 		</div>
 	);
 };

--- a/src/blocks/interactive-parent/view.js
+++ b/src/blocks/interactive-parent/view.js
@@ -1,6 +1,9 @@
 import Counter from '../../context/counter';
 import Theme from '../../context/theme';
-import { useState } from '../../gutenberg-packages/wordpress-element';
+import {
+	useState,
+	useErrorBoundary,
+} from '../../gutenberg-packages/wordpress-element';
 
 const View = ({
 	blockProps: {
@@ -13,6 +16,8 @@ const View = ({
 	const [show, setShow] = useState(true);
 	const [bold, setBold] = useState(true);
 	const [counter, setCounter] = useState(initialCounter);
+
+	const [error, resetError] = useErrorBoundary();
 
 	return (
 		<Counter.Provider value={counter}>
@@ -30,7 +35,15 @@ const View = ({
 					<button onClick={() => setCounter(counter + 1)}>
 						{counter}
 					</button>
-					{show && children}
+					{!error && show && children}
+					{error && (
+						<div>
+							<p>{error.toString()}</p>
+							<button onClick={resetError}>
+								Attempt recovery
+							</button>
+						</div>
+					)}
 				</div>
 			</Theme.Provider>
 		</Counter.Provider>

--- a/src/gutenberg-packages/wordpress-element.js
+++ b/src/gutenberg-packages/wordpress-element.js
@@ -5,6 +5,8 @@ import {
 	useState as usePreactState,
 } from 'preact/compat';
 
+import { useErrorBoundary as usePreactErrorBoundary } from 'preact/hooks';
+
 export const EnvContext = createContext('view');
 
 /**
@@ -12,7 +14,7 @@ export const EnvContext = createContext('view');
  *
  * Based on the workaround used for the Island Hydration approach, but only to differentiate between
  * Save and View, so this function and related hooks cannot be used inside Edit.
- * 
+ *
  * Note that the other approach was a bit hacky; this is a bit more hacky.
  *
  * @returns {"save" | "view"}
@@ -28,7 +30,7 @@ export const useBlockEnvironment = () => {
 
 const noop = () => {};
 
-export const useState = (init) => 
+export const useState = (init) =>
 	useBlockEnvironment() !== 'save' ? usePreactState(init) : [init, noop];
 
 export const useEffect = (...args) =>
@@ -38,3 +40,8 @@ export const useContext = (Context) =>
 	useBlockEnvironment() !== 'save'
 		? usePreactContext(Context)
 		: Context._currentValue;
+
+export const useErrorBoundary = (cb) =>
+	useBlockEnvironment() !== 'save'
+		? usePreactErrorBoundary(cb)
+		: [false, noop];

--- a/src/gutenberg-packages/wordpress-element.js
+++ b/src/gutenberg-packages/wordpress-element.js
@@ -3,9 +3,6 @@ import {
 	useContext as usePreactContext,
 	useEffect as usePreactEffect,
 	useState as usePreactState,
-	Suspense as PreactSuspense,
-	lazy as preactLazy,
-	createElement as h
 } from 'preact/compat';
 
 import { useErrorBoundary as usePreactErrorBoundary } from 'preact/hooks';
@@ -48,8 +45,3 @@ export const useErrorBoundary = (cb) =>
 	useBlockEnvironment() !== 'save'
 		? usePreactErrorBoundary(cb)
 		: [false, noop];
-
-export const Suspense = (props) =>
-	useBlockEnvironment() !== 'save' ? h(PreactSuspense, props) : props.fallback;
-
-export const lazy = preactLazy;

--- a/src/gutenberg-packages/wordpress-element.js
+++ b/src/gutenberg-packages/wordpress-element.js
@@ -3,6 +3,9 @@ import {
 	useContext as usePreactContext,
 	useEffect as usePreactEffect,
 	useState as usePreactState,
+	Suspense as PreactSuspense,
+	lazy as preactLazy,
+	createElement as h
 } from 'preact/compat';
 
 import { useErrorBoundary as usePreactErrorBoundary } from 'preact/hooks';
@@ -45,3 +48,8 @@ export const useErrorBoundary = (cb) =>
 	useBlockEnvironment() !== 'save'
 		? usePreactErrorBoundary(cb)
 		: [false, noop];
+
+export const Suspense = (props) =>
+	useBlockEnvironment() !== 'save' ? h(PreactSuspense, props) : props.fallback;
+
+export const lazy = preactLazy;


### PR DESCRIPTION
I've added two simple examples to check if `Suspense` and `useErrorBoundary` work out of the box. Using contexts was already tested, and it works fine, without any problems.

To test error boundaries, I did the following: ✅ 
- Added a button inside Interactive Child that makes the render throw an error.
- Used the `useErrorBoundary` hook inside Interactive Parent to render a fallback when an error reaches the component. The fallback shows a button to recover from the error.

To test `Suspense`, I added a lazy-loaded component that renders inside Interactive Child.  🚧