### PR TITLE
⚛️ Fix hydration when there are scripts in the top of the body

### DIFF
--- a/src/gutenberg-packages/to-vdom.js
+++ b/src/gutenberg-packages/to-vdom.js
@@ -15,7 +15,7 @@ export default function toVdom(n) {
 	// Get the node type.
 	const type = String(n.nodeName).toLowerCase();
 
-	if (type === 'script') return null;
+	if (type === 'script') return h('script');
 
 	// Extract props from node attributes.
 	const props = {};


### PR DESCRIPTION
@darerodz and I just discovered that hydration could fail if there are `<script>` tags at the top of the `<body>`, so instead of destroying them we can just return an empty `<script>`.