### PR TITLE
⚛️ Use `Suspense` and `lazy` to Hydrate views that were not registered before calling `hydrate()`

### DIFF
--- a/src/directives/wp-block-type.js
+++ b/src/directives/wp-block-type.js
@@ -66,8 +66,7 @@ directive('blockType', (wp, props, { vnode }) => {
 
 	if (!blockHydration) return;
 
-	// Use `lazy()` to pause hydration until the component is
-	// downloaded.
+	// Use `lazy()` to pause hydration until the component is registered.
 	const Component = lazy(() => blockViews.get(blockType));
 
 	if (blockUsesBlockContext.length) {

--- a/src/gutenberg-packages/block-views.js
+++ b/src/gutenberg-packages/block-views.js
@@ -1,0 +1,40 @@
+export default class BlockViews {
+	#components = new Map();
+	#resolvers = new Map();
+
+	/**
+	 * Set a Block component and resolve the associated Promise.
+	 *
+	 * @param {string} id The Block ID
+	 * @param {Component} Component The Block component.
+	 */
+	set(id, Component) {
+		// Views cannot be updated.
+		if (this.#components.has(id)) return;
+
+		// This component was not requested using `get` yet, so we can set a resolved Promise.
+		if (!this.#resolvers.has(id)) {
+			this.#components.set(id, Promise.resolve(Component));
+		} else {
+			// Resolve the current promise.
+			this.#resolvers.get(id)(Component);
+			this.#resolvers.delete(id);
+		}
+	}
+
+	/**
+	 * Return a Promise that resolves once the requested Block component exists.
+	 *
+	 * @param {string} id The Block ID.
+	 * @returns A Promise with the component.
+	 */
+	get(id) {
+		if (!this.#components.has(id)) {
+			this.#components.set(
+				id,
+				new Promise((res) => this.#resolvers.set(id, res))
+			);
+		}
+		return this.#components.get(id);
+	}
+}

--- a/src/gutenberg-packages/register-block-view.js
+++ b/src/gutenberg-packages/register-block-view.js
@@ -1,3 +1,5 @@
+import BlockViews from '../gutenberg-packages/block-views';
+
 // These functions need to be included in each block bundle because block
 // bundles must not have any hard dependency.
 const createGlobal = (name, initialValue) => {
@@ -9,15 +11,11 @@ const createGlobal = (name, initialValue) => {
 	return window.wp.view[name];
 };
 
-const blockViews = createGlobal('blockViews', new Map());
-const elementsToHydrate = createGlobal('elementsToHydrate', new Map());
+const blockViews = createGlobal('blockViews', new BlockViews());
 
-export default (name, Component, options) => {
-	blockViews.set(name, { Component, options });
-
-	if (elementsToHydrate.has(name)) {
-		for (const element of elementsToHydrate.get(name)) {
-			element.hydrate();
-		}
-	}
+export default (name, Component) => {
+	setTimeout(() => {
+		blockViews.set(name, Component);
+		console.log('registered view', name);
+	}, 5000);
 };


### PR DESCRIPTION
_Coauthored with @c4rl0sbr4v0_

This PR replaces the `Map` we used to store the View components with an object with a similar API. The difference is that the method `get` returns a promise that resolves once the View component is registered.

With that Promise, we can use `Suspense` and `lazy` to pause hydration until the components are ready.