### PR TITLE
🎨 Add wp-link attribute to all links

### DIFF
--- a/wp-directives.php
+++ b/wp-directives.php
@@ -40,9 +40,19 @@ add_action('init', 'wp_directives_register_scripts');
 
 function add_wp_link_attribute($block_content)
 {
+	$site_url = parse_url(get_site_url());
 	$w = new WP_HTML_Tag_Processor($block_content);
-	$w->next_tag('a');
-	$w->set_attribute('wp-link', 'true');
+	while ($w->next_tag('a')) {
+		$link = parse_url($w->get_attribute('href'));
+
+		if ($w->get_attribute('target') === '_blank') {
+			break;
+		}
+
+		if (is_null($link['host']) || ($link['host'] ===  $site_url['host'])) {
+			$w->set_attribute('wp-link', 'true');
+		}
+	};
 	return $w;
 }
 

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -43,17 +43,16 @@ function add_wp_link_attribute($block_content)
 	$site_url = parse_url(get_site_url());
 	$w = new WP_HTML_Tag_Processor($block_content);
 	while ($w->next_tag('a')) {
-		$link = parse_url($w->get_attribute('href'));
-
 		if ($w->get_attribute('target') === '_blank') {
 			break;
 		}
 
+		$link = parse_url($w->get_attribute('href'));
 		if (is_null($link['host']) || ($link['host'] ===  $site_url['host'])) {
 			$w->set_attribute('wp-link', 'true');
 		}
 	};
-	return $w;
+	return (string) $w;
 }
 
 add_filter('render_block', 'add_wp_link_attribute', 10, 2);

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Plugin Name:       wp-directives
  * Version:           0.1.0
@@ -36,3 +37,13 @@ function wp_directives_register_scripts()
 }
 
 add_action('init', 'wp_directives_register_scripts');
+
+function add_wp_link_attribute($block_content)
+{
+	$w = new WP_HTML_Tag_Processor($block_content);
+	$w->next_tag('a');
+	$w->set_attribute('wp-link', 'true');
+	return $w;
+}
+
+add_filter('render_block', 'add_wp_link_attribute', 10, 2);


### PR DESCRIPTION
I'm opening this Pull Request to "Add the wp-link to all the relative links on the page", one of the tasks of the [Tracking issue: WordPress Directives Plugin](https://github.com/WordPress/block-hydration-experiments/issues/80). This PR aims to just add that attribute in PHP, while all the logic will be handled within the directives in JS.

The first idea is to handle that in the [`render_block` filter](https://developer.wordpress.org/reference/hooks/render_block/) using the [WP_HTML_Tag_Processor](https://github.com/WordPress/gutenberg/pull/42485).