### PR TITLE
🎨 Add basic router and wp link directive

### DIFF
--- a/src/runtime/index.js
+++ b/src/runtime/index.js
@@ -8,12 +8,6 @@ import { init } from './router';
 document.addEventListener('DOMContentLoaded', async () => {
 	registerDirectives();
 	registerComponents();
-
-	// Do this manually to test it out.
-	document
-		.querySelectorAll('a')
-		.forEach((node) => node.setAttribute('wp-link', '{"prefetch": true }'));
-
 	await init();
 	console.log('hydrated!');
 });

--- a/src/runtime/index.js
+++ b/src/runtime/index.js
@@ -1,8 +1,6 @@
-import { hydrate } from 'preact';
 import registerDirectives from './directives';
 import registerComponents from './components';
-import toVdom from './vdom';
-import { createRootFragment } from './utils';
+import { init } from './router';
 
 /**
  * Initialize the initial vDOM.
@@ -11,14 +9,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 	registerDirectives();
 	registerComponents();
 
-	// Create the root fragment to hydrate everything.
-	const rootFragment = createRootFragment(
-		document.documentElement,
-		document.body
-	);
+	// Do this manually to test it out.
+	document
+		.querySelectorAll('a')
+		.forEach((node) => node.setAttribute('wp-link', '{"prefetch": true }'));
 
-	const vdom = toVdom(document.body);
-	hydrate(vdom, rootFragment);
-
+	await init();
 	console.log('hydrated!');
 });

--- a/src/runtime/router.js
+++ b/src/runtime/router.js
@@ -1,0 +1,65 @@
+import { hydrate, render } from 'preact';
+import toVdom from './vdom';
+import { createRootFragment } from './utils';
+
+// The root to render the vdom (document.body).
+let rootFragment;
+
+// The cache of visited and prefetched pages.
+export const pages = new Map();
+
+// Helper to remove domain and hash from the URL. We are only interesting in
+// caching the path and the query.
+const cleanUrl = (url) => {
+	const u = new URL(url, 'http://a.bc');
+	return u.pathname + u.search;
+};
+
+// Fetch a new page and convert it to a static virtual DOM.
+const fetchPage = async (url) => {
+	const html = await window.fetch(url).then((res) => res.text());
+	const dom = new window.DOMParser().parseFromString(html, 'text/html');
+	return toVdom(dom.body);
+};
+
+// Prefetch a page. We store the promise to avoid triggering a second fetch for
+// a page if a fetching has already started.
+export const prefetch = (url) => {
+	url = cleanUrl(url);
+	if (!pages.has(url)) {
+		pages.set(url, fetchPage(url));
+	}
+};
+
+// Navigate to a new page.
+export const navigate = async (href) => {
+	const url = cleanUrl(href);
+	prefetch(url);
+	const vdom = await pages.get(url);
+	render(vdom, rootFragment);
+	window.history.pushState({ wp: { clientNavigation: true } }, '', href);
+};
+
+// Listen to the back and forward buttons and restore the page if it's in the
+// cache.
+window.addEventListener('popstate', async () => {
+	const url = cleanUrl(window.location); // Remove hash.
+	if (pages.has(url)) {
+		const vdom = await pages.get(url);
+		render(vdom, rootFragment);
+	} else {
+		window.location.reload();
+	}
+});
+
+// Initialize the router with the initial DOM.
+export const init = async () => {
+	const url = cleanUrl(window.location); // Remove hash.
+
+	// Create the root fragment to hydrate everything.
+	rootFragment = createRootFragment(document.documentElement, document.body);
+
+	const vdom = toVdom(document.body);
+	pages.set(url, Promise.resolve(vdom));
+	hydrate(vdom, rootFragment);
+};

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Plugin Name:       wp-directives
  * Version:           0.1.0
@@ -48,7 +47,7 @@ function add_wp_link_attribute($block_content)
 		}
 
 		$link = parse_url($w->get_attribute('href'));
-		if (is_null($link['host']) || $link['host'] === $site_url['host']) {
+		if (!isset($link['host']) || $link['host'] === $site_url['host']) {
 			$w->set_attribute('wp-link', 'true');
 		}
 	}

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -36,7 +36,7 @@ function wp_directives_register_scripts()
 	wp_enqueue_script('wp-directive-runtime');
 }
 
-add_action('init', 'wp_directives_register_scripts');
+add_action('wp_enqueue_scripts', 'wp_directives_register_scripts');
 
 function add_wp_link_attribute($block_content)
 {
@@ -48,10 +48,10 @@ function add_wp_link_attribute($block_content)
 		}
 
 		$link = parse_url($w->get_attribute('href'));
-		if (is_null($link['host']) || ($link['host'] ===  $site_url['host'])) {
+		if (is_null($link['host']) || $link['host'] === $site_url['host']) {
 			$w->set_attribute('wp-link', 'true');
 		}
-	};
+	}
 	return (string) $w;
 }
 


### PR DESCRIPTION
_This PR is branched on top of https://github.com/WordPress/block-hydration-experiments/pull/82._

This PR adds the remaining functionality: router + `wp-link` directive.

It's pretty much a copy/paste of the [Query Loop block](https://github.com/WordPress/gutenberg/pull/44034) and [Product Query block](https://github.com/woocommerce/woocommerce-blocks/pull/7187) experiments.