### PR TITLE
🎨 Remove comments and preserve scripts

### DIFF
--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -1,18 +1,13 @@
-/**
- * External dependencies
- */
 import { h } from 'preact';
 
 // Recursive function that transfoms a DOM tree into vDOM.
 export default function toVdom(node) {
 	const props = {};
-	const attributes = node.attributes;
+	const { attributes, childNodes } = node;
 	const wpDirectives = {};
 	let hasWpDirectives = false;
 
 	if (node.nodeType === 3) return node.data;
-	if (node.nodeType === 8) return null;
-	if (node.localName === 'script') return h('script');
 
 	for (let i = 0; i < attributes.length; i++) {
 		const name = attributes[i].name;
@@ -32,11 +27,16 @@ export default function toVdom(node) {
 
 	if (hasWpDirectives) props.wp = wpDirectives;
 
-	// Walk child nodes and return vDOM children.
-	const children = [].map.call(node.childNodes, toVdom).filter(exists);
+	const children = [];
+	for (let i = 0; i < childNodes.length; i++) {
+		const child = childNodes[i];
+		if (child.nodeType === 8) {
+			child.remove();
+			i--;
+		} else {
+			children.push(toVdom(child));
+		}
+	}
 
 	return h(node.localName, props, children);
 }
-
-// Filter existing items.
-const exists = (x) => x;


### PR DESCRIPTION
I don't remember why we removed the script's children in the first place. We should investigate that, so let's preserve them again and see when they fail.

I've also added logic to remove the comments because [Preact doesn't support them during the hydration](https://github.com/WordPress/block-hydration-experiments/issues/79). We may need to add them back after the hydration if sites rely on them, but for now, I'd keep them removed.
