### PR TITLE
🎨 Add meta tag to opt-in to client-side navigations

### DIFF
--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -2,12 +2,15 @@ import { useContext, useMemo, useEffect } from 'preact/hooks';
 import { useSignalEffect } from '@preact/signals';
 import { directive } from './hooks';
 import { deepSignal } from './deepsignal';
-import { prefetch, navigate } from './router';
+import { prefetch, navigate, hasClientSideTransitions } from './router';
 import { getCallback } from './utils';
 
 const raf = window.requestAnimationFrame;
 // Until useSignalEffects is fixed: https://github.com/preactjs/signals/issues/228
 const tick = () => new Promise((r) => raf(() => raf(r)));
+
+// Check if current page has client-side transitions enabled.
+const clientSideTransitions = hasClientSideTransitions(document.head);
 
 export default () => {
 	// wp-context
@@ -95,13 +98,13 @@ export default () => {
 		}) => {
 			useEffect(() => {
 				// Prefetch the page if it is in the directive options.
-				if (link?.prefetch) {
+				if (clientSideTransitions && link?.prefetch) {
 					prefetch(href);
 				}
 			});
 
 			// Don't do anything if it's falsy.
-			if (link !== false) {
+			if (clientSideTransitions && link !== false) {
 				element.props.onclick = async (event) => {
 					event.preventDefault();
 

--- a/src/runtime/router.js
+++ b/src/runtime/router.js
@@ -5,7 +5,7 @@ import { createRootFragment } from './utils';
 // The root to render the vdom (document.body).
 let rootFragment;
 
-// The cache of visited and prefetched pages.
+// The cache of visited and prefetched pages and stylesheets.
 const pages = new Map();
 const stylesheets = new Map();
 
@@ -15,6 +15,12 @@ const cleanUrl = (url) => {
 	const u = new URL(url, 'http://a.bc');
 	return u.pathname + u.search;
 };
+
+// Helper to check if a page has client-side transitions activated.
+export const hasClientSideTransitions = (dom) =>
+	dom
+		.querySelector("meta[itemprop='wp-client-side-transitions']")
+		?.getAttribute('content') === 'active';
 
 // Fetch styles of a new page.
 const fetchHead = async (head) => {
@@ -45,6 +51,7 @@ const fetchHead = async (head) => {
 const fetchPage = async (url) => {
 	const html = await window.fetch(url).then((r) => r.text());
 	const dom = new window.DOMParser().parseFromString(html, 'text/html');
+	if (!hasClientSideTransitions(dom.head)) return false;
 	const head = await fetchHead(dom.head);
 	return { head, body: toVdom(dom.body) };
 };
@@ -62,20 +69,24 @@ export const prefetch = (url) => {
 export const navigate = async (href) => {
 	const url = cleanUrl(href);
 	prefetch(url);
-	const { body, head } = await pages.get(url);
-	document.head.replaceChildren(...head);
-	render(body, rootFragment);
-	window.history.pushState({ wp: { clientNavigation: true } }, '', href);
+	const page = await pages.get(url);
+	if (page) {
+		document.head.replaceChildren(...page.head);
+		render(page.body, rootFragment);
+		window.history.pushState({}, '', href);
+	} else {
+		window.location.assign(href);
+	}
 };
 
 // Listen to the back and forward buttons and restore the page if it's in the
 // cache.
 window.addEventListener('popstate', async () => {
 	const url = cleanUrl(window.location); // Remove hash.
-	if (pages.has(url)) {
-		const { body, head } = await pages.get(url);
-		document.head.replaceChildren(...head);
-		render(body, rootFragment);
+	const page = pages.has(url) && (await pages.get(url));
+	if (page) {
+		document.head.replaceChildren(...page.head);
+		render(page.body, rootFragment);
 	} else {
 		window.location.reload();
 	}
@@ -83,13 +94,13 @@ window.addEventListener('popstate', async () => {
 
 // Initialize the router with the initial DOM.
 export const init = async () => {
-	const url = cleanUrl(window.location); // Remove hash.
-
 	// Create the root fragment to hydrate everything.
 	rootFragment = createRootFragment(document.documentElement, document.body);
-
 	const body = toVdom(document.body);
 	hydrate(body, rootFragment);
-	const head = await fetchHead(document.head);
-	pages.set(url, Promise.resolve({ body, head }));
+
+	if (hasClientSideTransitions(document.head)) {
+		const head = await fetchHead(document.head);
+		pages.set(cleanUrl(window.location), Promise.resolve({ body, head }));
+	}
 };

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -34,10 +34,9 @@ function wp_directives_register_scripts()
 	// conditionally enqueue directives later.
 	wp_enqueue_script('wp-directive-runtime');
 }
-
 add_action('wp_enqueue_scripts', 'wp_directives_register_scripts');
 
-function add_wp_link_attribute($block_content)
+function wp_directives_add_wp_link_attribute($block_content)
 {
 	$site_url = parse_url(get_site_url());
 	$w = new WP_HTML_Tag_Processor($block_content);
@@ -53,5 +52,15 @@ function add_wp_link_attribute($block_content)
 	}
 	return (string) $w;
 }
+add_filter('render_block', 'wp_directives_add_wp_link_attribute', 10, 2);
 
-add_filter('render_block', 'add_wp_link_attribute', 10, 2);
+function wp_directives_client_site_transitions_meta_tag()
+{
+	if (apply_filters('client_side_transitions', false)) {
+		echo '<meta itemprop="wp-client-side-transitions" content="active">';
+	}
+}
+add_action('wp_head', 'wp_directives_client_site_transitions_meta_tag', 10, 0);
+
+/* User code */
+add_filter('client_side_transitions', '__return_true');


### PR DESCRIPTION
I've added a mechanism to opt-in to client-side navigations using a metatag, so navigation can do a fallback after receiving the HTML of a page that is not client-side navigation friendly.

I left them activated by default for now, although I want to add an admin screen to toggle them on and off.

<a href="https://www.loom.com/share/32bfdeb904e04c7e933474744e11be81">
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/32bfdeb904e04c7e933474744e11be81-with-play.gif">
  </a>

https://www.loom.com/share/32bfdeb904e04c7e933474744e11be81
