### PR TITLE
🎨 Add `prefetch` to all links and prevent scroll in pagination

### DIFF
--- a/wp-directives.php
+++ b/wp-directives.php
@@ -47,8 +47,8 @@ function add_wp_link_attribute($block_content)
 		}
 
 		$link = parse_url($w->get_attribute('href'));
-		$classes = $w->get_attribute('class');
 		if (!isset($link['host']) || $link['host'] === $site_url['host']) {
+			$classes = $w->get_attribute('class');
 			if (str_contains($classes, 'query-pagination') || str_contains($classes, 'page-numbers')) {
 				$w->set_attribute('wp-link', '{ "prefetch": true, "scroll": false }');
 			} else {

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -47,11 +47,18 @@ function add_wp_link_attribute($block_content)
 		}
 
 		$link = parse_url($w->get_attribute('href'));
+		$classes = $w->get_attribute('class');
 		if (!isset($link['host']) || $link['host'] === $site_url['host']) {
-			$w->set_attribute('wp-link', 'true');
+			if (str_contains($classes, 'query-pagination') || str_contains($classes, 'page-numbers')) {
+				$w->set_attribute('wp-link', '{ "prefetch": true, "scroll": false }');
+			} else {
+				$w->set_attribute('wp-link', '{ "prefetch": true }');
+			}
 		}
 	}
 	return (string) $w;
 }
 
-add_filter('render_block', 'add_wp_link_attribute', 10, 2);
+// We go only through the Query Loops and the template parts until we find a better solution.
+add_filter('render_block_core/query', 'add_wp_link_attribute', 10, 1);
+add_filter('render_block_core/template-part', 'add_wp_link_attribute', 10, 1);


### PR DESCRIPTION
I've added the `prefetch` property to all the links and `scroll=false` to all the pagination links. While doing so we realized that the HTML of the parent blocks contain the children, so we were parsing the HTML multiple times. For that, we change the filters to only trigger for the Query Loop and the Template Parts until we figure out a better solution.