### PR TITLE
🎨 Admin for client side navigations

### DIFF
--- a/src/admin/admin-page.php
+++ b/src/admin/admin-page.php
@@ -1,0 +1,82 @@
+<?php
+
+function wp_directives_register_menu()
+{
+	add_options_page(
+		'WP Directives',
+		'WP Directives',
+		'manage_options',
+		'wp-directives-plugin',
+		'wp_directives_render_admin_page'
+	);
+}
+add_action('admin_menu', 'wp_directives_register_menu');
+
+function wp_directives_render_admin_page()
+{
+	?>
+    <div class="wrap">
+      <h2>WP Directives</h2>
+      <form method="POST" action="options.php">
+          <?php
+          settings_fields('wp_directives_plugin_settings');
+          do_settings_sections('wp_directives_plugin_page');
+          ?>
+          <?php submit_button(); ?>
+      </form>
+    </div>
+  <?php
+}
+
+function wp_directives_register_settings()
+{
+	register_setting(
+		'wp_directives_plugin_settings',
+		'wp_directives_plugin_settings',
+		[
+			'type' => 'object',
+			'default' => [
+				'client_side_transitions' => false,
+			],
+			'sanitize_callback' => 'wp_directives_validate_settings',
+		]
+	);
+
+	add_settings_section(
+		'wp_directives_plugin_section',
+		'',
+		null,
+		'wp_directives_plugin_page'
+	);
+
+	add_settings_field(
+		'client_side_transitions',
+		'Client Side Transitions',
+		'wp_directives_client_side_transitions_input',
+		'wp_directives_plugin_page',
+		'wp_directives_plugin_section'
+	);
+}
+add_action('admin_init', 'wp_directives_register_settings');
+
+function wp_directives_validate_settings($input)
+{
+	$output = get_option('wp_directives_plugin_settings');
+	$output['client_side_transitions'] =
+		isset($input) && $input['client_side_transitions'] ? true : false;
+	return $output;
+}
+
+function wp_directives_client_side_transitions_input()
+{
+	$options = get_option('wp_directives_plugin_settings'); ?>
+
+	<input type="checkbox" 
+		name="<?= esc_attr(
+  	'wp_directives_plugin_settings[client_side_transitions]'
+  ) ?>" 
+		<?= $options['client_side_transitions'] ? 'checked' : '' ?>
+	>
+
+	<?php
+}

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -10,6 +10,33 @@
  * Text Domain:       wp-directives
  */
 
+function wp_directives_loader()
+{
+	// Load the Admin page.
+	require_once plugin_dir_path(__FILE__) . '/src/admin/admin-page.php';
+}
+add_action('plugins_loaded', 'wp_directives_loader');
+
+/**
+ * Add default settings upon activation.
+ */
+function wp_directives_activate()
+{
+	add_option('wp_directives_plugin_settings', [
+		'client_side_transitions' => false,
+	]);
+}
+register_activation_hook(__FILE__, 'wp_directives_activate');
+
+/**
+ * Delete settings on uninstall.
+ */
+function wp_directives_uninstall()
+{
+	delete_option('wp_directives_plugin_settings');
+}
+register_uninstall_hook(__FILE__, 'wp_directives_uninstall');
+
 /**
  * Register the scripts
  */
@@ -63,4 +90,12 @@ function wp_directives_client_site_transitions_meta_tag()
 add_action('wp_head', 'wp_directives_client_site_transitions_meta_tag', 10, 0);
 
 /* User code */
-add_filter('client_side_transitions', '__return_true');
+function wp_directives_client_site_transitions_option()
+{
+	$options = get_option('wp_directives_plugin_settings');
+	return $options['client_side_transitions'];
+}
+add_filter(
+	'client_side_transitions',
+	'wp_directives_client_site_transitions_option'
+);


### PR DESCRIPTION
It's just an admin page to opt-in to the client-side navigations.

I did it on top of https://github.com/WordPress/block-hydration-experiments/pull/86, so we need to merge that one first.

<img width="528" alt="Screenshot 2022-10-19 at 20 07 20" src="https://user-images.githubusercontent.com/3305402/196770479-613923a7-8055-4dcd-8bd5-3f03a08f3911.png">

**This is meant for testing only. It doesn't mean we intend to add an option to WordPress**.

If you had the plugin installed before, please deactivate and activate the plugin again so it creates the default settings.


