### PR TITLE
🎨 Preserve client components in the DOM

### DIFF
--- a/src/runtime/hooks.js
+++ b/src/runtime/hooks.js
@@ -38,8 +38,11 @@ options.vnode = (vnode) => {
 	const wp = vnode.props.wp;
 
 	if (typeof type === 'string' && type.startsWith('wp-')) {
-		vnode.type = components[type];
-		vnode.props.context = context;
+		vnode.props.children = h(
+			components[type],
+			{ ...vnode.props, context },
+			vnode.props.children
+		);
 	}
 
 	if (wp) {


### PR DESCRIPTION
This is a small fix to preserve client components in the DOM because we were inadvertently deleting them until now.

<a href="https://www.loom.com/share/56f6c98eb47c4d9a91c6f6816512ce9e">
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/56f6c98eb47c4d9a91c6f6816512ce9e-with-play.gif">
  </a>

https://www.loom.com/share/56f6c98eb47c4d9a91c6f6816512ce9e