### PR TITLE
🎨 Fix context not updated on prop change

### DIFF
--- a/src/runtime/components.js
+++ b/src/runtime/components.js
@@ -4,7 +4,7 @@ import { component } from './hooks';
 
 export default () => {
 	const WpContext = ({ children, data, context: { Provider } }) => {
-		const signals = useMemo(() => deepSignal(JSON.parse(data)), []);
+		const signals = useMemo(() => deepSignal(JSON.parse(data)), [data]);
 		return <Provider value={signals}>{children}</Provider>;
 	};
 	component('wp-context', WpContext);

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -17,11 +17,13 @@ export default () => {
 	directive(
 		'context',
 		({
-			directives: { context },
+			directives: {
+				context: { default: context },
+			},
 			props: { children },
 			context: { Provider },
 		}) => {
-			const signals = useMemo(() => deepSignal(context.default), []);
+			const signals = useMemo(() => deepSignal(context), [context]);
 			return <Provider value={signals}>{children}</Provider>;
 		}
 	);


### PR DESCRIPTION
I did another small fix for the `wp-context` that was not being updated whenever the prop or the attribute changed.

<a href="https://www.loom.com/share/f8806d4cc9ad4580984eff98cb2dfcd9">
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/f8806d4cc9ad4580984eff98cb2dfcd9-with-play.gif">
  </a>

https://www.loom.com/share/f8806d4cc9ad4580984eff98cb2dfcd9