### PR TITLE
Use `page.evaluate` instead of `page.addScriptTag`

### DIFF
--- a/benchmark/index.mjs
+++ b/benchmark/index.mjs
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import playwright from 'playwright';
 import { join } from 'path';
 import { inspect } from 'util';
@@ -45,9 +46,11 @@ const dirname = process.cwd();
 				timeout: 30000,
 			});
 
-			await page.addScriptTag({
-				path: join(dirname, './build/hydrationScriptForTesting.js'),
-			});
+			const preloadFile = fs.readFileSync(
+				'./build/hydrationScriptForTesting.js',
+				'utf8'
+			);
+			await page.evaluate(preloadFile);
 
 			page.on('console', async (msg) => {
 				const message = msg.text();


### PR DESCRIPTION
I was testing the workflow with different sites and in some of them ([TechCrunch](https://href.li/?https://techcrunch.com/) and [The Hill](https://href.li/?https://thehill.com/) for example), there was a Content Security Policy error:

`Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'unsafe-eval' 'none'`

I think that this can be solved using `evaluate` instead of `addScripTag`.