### PR TITLE
Register 403 errors in the results.db

### DIFF
--- a/benchmark/index.mjs
+++ b/benchmark/index.mjs
@@ -72,7 +72,7 @@ async function testUrl(url, browser) {
 		});
 
 		if (response.status() === 403) {
-			throw '403 error - ' + url;
+			throw '403 error';
 		}
 
 		const preloadFile = fs.readFileSync(

--- a/benchmark/index.mjs
+++ b/benchmark/index.mjs
@@ -66,27 +66,13 @@ async function testUrl(url, browser) {
 
 		console.log(`Navigating to ${url}\n`);
 
-		let error403 = false;
-
-		page.on('response', async (msg) => {
-			const urlObject = new URL(msg.url());
-
-			// Check if the url returns a 403
-			if (
-				urlObject.hostname + urlObject.pathname === url &&
-				msg.status() === 403
-			) {
-				error403 = true;
-			}
-		});
-
-		await page.goto(`http://${url}`, {
+		const response = await page.goto(`http://${url}`, {
 			waitUntil: 'networkidle',
 			timeout: 60000,
 		});
 
-		if (error403) {
-			throw '403 error';
+		if (response.status() === 403) {
+			throw '403 error - ' + url;
 		}
 
 		const preloadFile = fs.readFileSync(

--- a/benchmark/models.mjs
+++ b/benchmark/models.mjs
@@ -28,7 +28,8 @@ export const createModels = (sequelize) => {
 				'success',
 				'hydrationError',
 				'timeoutError',
-				'error'
+				'error',
+				'403error'
 			),
 		},
 		{


### PR DESCRIPTION
In some situations, for different reasons, we may not have access to the page, and we shouldn't register that as a success. For example, we are aware that Cloudflare could block it because we are doing too many requests. We are trying to solve Cloudflare use case, but there may be others, so I made this PR in case we want to register that.