### PR TITLE
Add database name as parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+.DS_Store

--- a/benchmark/index.mjs
+++ b/benchmark/index.mjs
@@ -14,9 +14,9 @@ const {
 	_,
 	concurrency,
 	cloudflare: testCloudflare,
-	database = 'test_results',
+	database,
 } = minimist(process.argv.slice(2), {
-	default: { cloudflare: false },
+	default: { cloudflare: false, database: 'test_results' },
 });
 const fileArg = _[0];
 if (typeof fileArg === 'undefined') {

--- a/benchmark/index.mjs
+++ b/benchmark/index.mjs
@@ -14,6 +14,7 @@ const {
 	_,
 	concurrency,
 	cloudflare: testCloudflare,
+	database = 'test_results',
 } = minimist(process.argv.slice(2), {
 	default: { cloudflare: false },
 });
@@ -29,7 +30,7 @@ if (typeof fileArg === 'undefined') {
 // Initialize the database
 const sequelize = new Sequelize({
 	dialect: 'sqlite',
-	storage: new URL('./test_results.db', import.meta.url).pathname,
+	storage: new URL(`./${database}.db`, import.meta.url).pathname,
 	logging: false,
 });
 


### PR DESCRIPTION
Adding the database name as an optional parameter to the script may help prevent unwanted conflicts between database_results when executing the tests.