### PR TITLE
Make `attributes.length` optional

### DIFF
--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -9,19 +9,21 @@ export default function toVdom(node) {
 
 	if (node.nodeType === 3) return node.data;
 
-	for (let i = 0; i < attributes?.length; i++) {
-		const name = attributes[i].name;
-		if (name.startsWith('wp-')) {
-			hasWpDirectives = true;
-			let val = attributes[i].value;
-			try {
-				val = JSON.parse(val);
-			} catch (e) {}
-			const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(name);
-			wpDirectives[prefix] = wpDirectives[prefix] || {};
-			wpDirectives[prefix][suffix || 'default'] = val;
-		} else {
-			props[name] = attributes[i].value;
+	if (attributes) {
+		for (let i = 0; i < attributes?.length; i++) {
+			const name = attributes[i].name;
+			if (name.startsWith('wp-')) {
+				hasWpDirectives = true;
+				let val = attributes[i].value;
+				try {
+					val = JSON.parse(val);
+				} catch (e) {}
+				const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(name);
+				wpDirectives[prefix] = wpDirectives[prefix] || {};
+				wpDirectives[prefix][suffix || 'default'] = val;
+			} else {
+				props[name] = attributes[i].value;
+			}
 		}
 	}
 

--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -9,7 +9,7 @@ export default function toVdom(node) {
 
 	if (node.nodeType === 3) return node.data;
 
-	for (let i = 0; i < attributes.length; i++) {
+	for (let i = 0; i < attributes?.length; i++) {
 		const name = attributes[i].name;
 		if (name.startsWith('wp-')) {
 			hasWpDirectives = true;


### PR DESCRIPTION
We have found a couple of sites where our hydration script is failing because `attributes.length` is `undefined`. It seems that adding `?` to it to make it optional solves the problem. These are the sites where it is failing:
* [tiens-donc.com](http://tiens-donc.com/)
* [yourcontentempire.com](http://yourcontentempire.com/)