### PR TITLE
Check undefined attributes in the stress testing

### DIFF
--- a/benchmark/manual-testing-script.js
+++ b/benchmark/manual-testing-script.js
@@ -643,19 +643,21 @@
 		const wpDirectives = {};
 		let hasWpDirectives = false;
 		if (node.nodeType === 3) return node.data;
-		for (let i2 = 0; i2 < attributes.length; i2++) {
-			const name = attributes[i2].name;
-			if (name.startsWith('wp-')) {
-				hasWpDirectives = true;
-				let val = attributes[i2].value;
-				try {
-					val = JSON.parse(val);
-				} catch (e2) {}
-				const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(name);
-				wpDirectives[prefix] = wpDirectives[prefix] || {};
-				wpDirectives[prefix][suffix || 'default'] = val;
-			} else {
-				props[name] = attributes[i2].value;
+		if (attributes) {
+			for (let i2 = 0; i2 < attributes?.length; i2++) {
+				const name = attributes[i2].name;
+				if (name.startsWith('wp-')) {
+					hasWpDirectives = true;
+					let val = attributes[i2].value;
+					try {
+						val = JSON.parse(val);
+					} catch (e2) {}
+					const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(name);
+					wpDirectives[prefix] = wpDirectives[prefix] || {};
+					wpDirectives[prefix][suffix || 'default'] = val;
+				} else {
+					props[name] = attributes[i2].value;
+				}
 			}
 		}
 		if (hasWpDirectives) props.wp = wpDirectives;

--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -9,19 +9,21 @@ export default function toVdom(node) {
 
 	if (node.nodeType === 3) return node.data;
 
-	for (let i = 0; i < attributes.length; i++) {
-		const name = attributes[i].name;
-		if (name.startsWith('wp-')) {
-			hasWpDirectives = true;
-			let val = attributes[i].value;
-			try {
-				val = JSON.parse(val);
-			} catch (e) {}
-			const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(name);
-			wpDirectives[prefix] = wpDirectives[prefix] || {};
-			wpDirectives[prefix][suffix || 'default'] = val;
-		} else {
-			props[name] = attributes[i].value;
+	if (attributes) {
+		for (let i = 0; i < attributes?.length; i++) {
+			const name = attributes[i].name;
+			if (name.startsWith('wp-')) {
+				hasWpDirectives = true;
+				let val = attributes[i].value;
+				try {
+					val = JSON.parse(val);
+				} catch (e) {}
+				const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(name);
+				wpDirectives[prefix] = wpDirectives[prefix] || {};
+				wpDirectives[prefix][suffix || 'default'] = val;
+			} else {
+				props[name] = attributes[i].value;
+			}
 		}
 	}
 


### PR DESCRIPTION
I'm just replicating the changes made in [this other Pull Request](https://github.com/WordPress/block-hydration-experiments/pull/107) to ensure this doesn't happen in the stress-testing.