### PR TITLE
[Stress testing] Replace `startsWith` in the `toVdom` function

### DIFF
--- a/benchmark/manual-testing-script.js
+++ b/benchmark/manual-testing-script.js
@@ -644,18 +644,18 @@
 		let hasWpDirectives = false;
 		if (node.nodeType === 3) return node.data;
 		for (let i2 = 0; i2 < attributes.length; i2++) {
-			const name = attributes[i2].name;
-			if (name.startsWith('wp-')) {
+			const n = attributes[i2].name;
+			if (n[0] === 'w' && n[1] === 'p' && n[2] === '-' && n[3]) {
 				hasWpDirectives = true;
 				let val = attributes[i2].value;
 				try {
 					val = JSON.parse(val);
 				} catch (e2) {}
-				const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(name);
+				const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(n);
 				wpDirectives[prefix] = wpDirectives[prefix] || {};
 				wpDirectives[prefix][suffix || 'default'] = val;
 			} else {
-				props[name] = attributes[i2].value;
+				props[n] = attributes[i2].value;
 			}
 		}
 		if (hasWpDirectives) props.wp = wpDirectives;

--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -10,18 +10,18 @@ export default function toVdom(node) {
 	if (node.nodeType === 3) return node.data;
 
 	for (let i = 0; i < attributes.length; i++) {
-		const name = attributes[i].name;
-		if (name.startsWith('wp-')) {
+		const n = attributes[i].name;
+		if (n[0] === 'w' && n[1] === 'p' && n[2] === '-' && n[3]) {
 			hasWpDirectives = true;
 			let val = attributes[i].value;
 			try {
 				val = JSON.parse(val);
 			} catch (e) {}
-			const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(name);
+			const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(n);
 			wpDirectives[prefix] = wpDirectives[prefix] || {};
 			wpDirectives[prefix][suffix || 'default'] = val;
 		} else {
-			props[name] = attributes[i].value;
+			props[n] = attributes[i].value;
 		}
 	}
 


### PR DESCRIPTION
I'm just replicating the final implementation of this PR https://github.com/WordPress/block-hydration-experiments/pull/99, but in the stress-testing branch.