### PR TITLE
Fix hydration error `root fragment` is not defined in the stress testing

### DIFF
--- a/benchmark/hydrationScript.js
+++ b/benchmark/hydrationScript.js
@@ -7,7 +7,10 @@ import { createRootFragment } from '../src/runtime/utils';
 
 function runHydration() {
 	// Create the root fragment to hydrate everything.
-	rootFragment = createRootFragment(document.documentElement, document.body);
+	const rootFragment = createRootFragment(
+		document.documentElement,
+		document.body
+	);
 	const body = toVdom(document.body);
 	hydrate(body, rootFragment);
 }


### PR DESCRIPTION
Now that we are registering the `hydrationError`, I was running the script on some sites, and there wasn't any `success` registered. It seems all of them are returning the following `hydrationError`: `rootFragment is not defined`.

After triaging it with @c4rl0sbr4v0 and @luisherranz , it seems the issue comes from defining `rootFragment` as a global. Defining it as a local variable seems to solve the problem.