### PR TITLE
Handle CDATA nodes

### DIFF
--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -8,6 +8,10 @@ export default function toVdom(node) {
 	let hasWpDirectives = false;
 
 	if (node.nodeType === 3) return node.data;
+	if (node.nodeType === 4) {
+		node.replaceWith(new Text(node.nodeValue));
+		return node.nodeValue;
+	}
 
 	for (let i = 0; i < attributes.length; i++) {
 		const n = attributes[i].name;

--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -9,21 +9,19 @@ export default function toVdom(node) {
 
 	if (node.nodeType === 3) return node.data;
 
-	if (attributes) {
-		for (let i = 0; i < attributes.length; i++) {
-			const n = attributes[i].name;
-			if (n[0] === 'w' && n[1] === 'p' && n[2] === '-' && n[3]) {
-				hasWpDirectives = true;
-				let val = attributes[i].value;
-				try {
-					val = JSON.parse(val);
-				} catch (e) {}
-				const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(n);
-				wpDirectives[prefix] = wpDirectives[prefix] || {};
-				wpDirectives[prefix][suffix || 'default'] = val;
-			} else {
-				props[n] = attributes[i].value;
-			}
+	for (let i = 0; i < attributes.length; i++) {
+		const n = attributes[i].name;
+		if (n[0] === 'w' && n[1] === 'p' && n[2] === '-' && n[3]) {
+			hasWpDirectives = true;
+			let val = attributes[i].value;
+			try {
+				val = JSON.parse(val);
+			} catch (e) {}
+			const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(n);
+			wpDirectives[prefix] = wpDirectives[prefix] || {};
+			wpDirectives[prefix][suffix || 'default'] = val;
+		} else {
+			props[n] = attributes[i].value;
 		}
 	}
 


### PR DESCRIPTION
I'm creating this Pull Request with the solution proposed at https://github.com/WordPress/block-hydration-experiments/issues/109

I also reverted https://github.com/WordPress/block-hydration-experiments/pull/107. I made that one trying to solve the problem with `attributes` being `undefined` caused by the `CDATA` nodes. However, now that this is handled properly, it makes sense to revert that change in case we encounter another similar use case with undefined attributes. We should identify them and not skip them.