### PR TITLE
WP Directives Plugin: Require Gutenberg plugin to avoid a fatal error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 build
+vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,41 @@
+{
+	"name": "wordpress/block-hydration-experiments",
+	"type": "wordpress-plugin",
+	"license": "GPL-2.0-or-later",
+	"description": "Experiments with frontend hydration for blocks",
+	"homepage": "https://wordpress.github.io/gutenberg/",
+	"keywords": [
+		"block-hydration-experiments",
+		"wordpress",
+		"wp",
+		"react",
+		"javascript"
+	],
+	"support": {
+		"issues": "https://github.com/WordPress/block-hydration-experiments/issues"
+	},
+	"config": {
+		"process-timeout": 0,
+		"platform": {
+			"php": "7.4"
+		},
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"composer/installers": true
+		}
+	},
+	"require-dev": {
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+		"squizlabs/php_codesniffer": "^3.5",
+		"phpcompatibility/phpcompatibility-wp": "^2.1.3",
+		"wp-coding-standards/wpcs": "^2.2",
+		"sirbrillig/phpcs-variable-analysis": "^2.8"
+	},
+	"require": {
+		"composer/installers": "~1.0"
+	},
+	"scripts": {
+		"format": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
+		"lint": "phpcs --standard=phpcs.xml.dist"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
 		"build": "webpack --mode=production",
 		"start": "webpack --mode=development --watch",
 		"dev": "npm start",
+		"format:php": "wp-env run composer run-script format",
+		"lint:php": "wp-env run composer run-script lint",
 		"test": "jest",
 		"test:watch": "jest --watch",
 		"plugin-zip": "wp-scripts plugin-zip",

--- a/src/admin/admin-page.php
+++ b/src/admin/admin-page.php
@@ -1,7 +1,6 @@
 <?php
 
-function wp_directives_register_menu()
-{
+function wp_directives_register_menu() {
 	add_options_page(
 		'WP Directives',
 		'WP Directives',
@@ -10,36 +9,33 @@ function wp_directives_register_menu()
 		'wp_directives_render_admin_page'
 	);
 }
-add_action('admin_menu', 'wp_directives_register_menu');
+add_action( 'admin_menu', 'wp_directives_register_menu' );
 
-function wp_directives_render_admin_page()
-{
-	?>
-    <div class="wrap">
-      <h2>WP Directives</h2>
-      <form method="POST" action="options.php">
-          <?php
-          settings_fields('wp_directives_plugin_settings');
-          do_settings_sections('wp_directives_plugin_page');
-          ?>
-          <?php submit_button(); ?>
-      </form>
-    </div>
-  <?php
+function wp_directives_render_admin_page() {?>
+	<div class="wrap">
+		<h2>WP Directives</h2>
+		<form method="POST" action="options.php">
+			<?php
+				settings_fields( 'wp_directives_plugin_settings' );
+				do_settings_sections( 'wp_directives_plugin_page' );
+			?>
+			<?php submit_button(); ?>
+		</form>
+	</div>
+	<?php
 }
 
-function wp_directives_register_settings()
-{
+function wp_directives_register_settings() {
 	register_setting(
 		'wp_directives_plugin_settings',
 		'wp_directives_plugin_settings',
-		[
-			'type' => 'object',
-			'default' => [
+		array(
+			'type'              => 'object',
+			'default'           => array(
 				'client_side_transitions' => false,
-			],
+			),
 			'sanitize_callback' => 'wp_directives_validate_settings',
-		]
+		)
 	);
 
 	add_settings_section(
@@ -57,25 +53,28 @@ function wp_directives_register_settings()
 		'wp_directives_plugin_section'
 	);
 }
-add_action('admin_init', 'wp_directives_register_settings');
+add_action( 'admin_init', 'wp_directives_register_settings' );
 
-function wp_directives_validate_settings($input)
-{
-	$output = get_option('wp_directives_plugin_settings');
+function wp_directives_validate_settings( $input ) {
+	$output                            = get_option( 'wp_directives_plugin_settings' );
 	$output['client_side_transitions'] =
-		isset($input) && $input['client_side_transitions'] ? true : false;
+		isset( $input ) && $input['client_side_transitions'] ? true : false;
 	return $output;
 }
 
-function wp_directives_client_side_transitions_input()
-{
-	$options = get_option('wp_directives_plugin_settings'); ?>
+function wp_directives_client_side_transitions_input() {
+	$options = get_option( 'wp_directives_plugin_settings' );
+	?>
 
 	<input type="checkbox" 
-		name="<?= esc_attr(
-  	'wp_directives_plugin_settings[client_side_transitions]'
-  ) ?>" 
-		<?= $options['client_side_transitions'] ? 'checked' : '' ?>
+		name="
+		<?php
+		echo esc_attr(
+			'wp_directives_plugin_settings[client_side_transitions]'
+		)
+		?>
+		" 
+		<?php echo $options['client_side_transitions'] ? 'checked' : ''; ?>
 	>
 
 	<?php

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -10,8 +10,20 @@
  * Text Domain:       wp-directives
  */
 
+ // Check if Gutenberg plugin is active
+if (!function_exists('is_plugin_active')) {
+    include_once(ABSPATH . 'wp-admin/includes/plugin.php');
+}
+if ( ! is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
+    // Show an error message
+    add_action( 'admin_notices', function() {
+		echo sprintf( '<div class="error"><p>%s</p></div>', __( 'This plugin requires the Gutenberg plugin to be installed and activated.', 'wp-directives' ) );
+    });
 
-
+    // Deactivate the plugin
+    deactivate_plugins( plugin_basename( __FILE__ ) );
+    return;
+}
 
 function wp_directives_loader()
 {
@@ -109,18 +121,3 @@ add_filter(
 	'client_side_transitions',
 	'wp_directives_client_site_transitions_option'
 );
-
-// Check if Gutenberg plugin is active
-if (!function_exists('is_plugin_active')) {
-    include_once(ABSPATH . 'wp-admin/includes/plugin.php');
-}
-if ( ! is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
-    // Show an error message
-    add_action( 'admin_notices', function() {
-		echo sprintf( '<div class="error"><p>%s</p></div>', __( 'This plugin requires the Gutenberg plugin to be installed and activated.', 'wp-directives' ) );
-    });
-
-    // Deactivate the plugin
-    deactivate_plugins( plugin_basename( __FILE__ ) );
-    return;
-}

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -11,110 +11,109 @@
  */
 
  // Check if Gutenberg plugin is active
-if (!function_exists('is_plugin_active')) {
-    include_once(ABSPATH . 'wp-admin/includes/plugin.php');
+if ( ! function_exists( 'is_plugin_active' ) ) {
+	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 }
 if ( ! is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
-    // Show an error message
-    add_action( 'admin_notices', function() {
-		echo sprintf( '<div class="error"><p>%s</p></div>', __( 'This plugin requires the Gutenberg plugin to be installed and activated.', 'wp-directives' ) );
-    });
+	// Show an error message
+	add_action(
+		'admin_notices',
+		function() {
+			echo sprintf( '<div class="error"><p>%s</p></div>', __( 'This plugin requires the Gutenberg plugin to be installed and activated.', 'wp-directives' ) );
+		}
+	);
 
-    // Deactivate the plugin
-    deactivate_plugins( plugin_basename( __FILE__ ) );
-    return;
+	// Deactivate the plugin
+	deactivate_plugins( plugin_basename( __FILE__ ) );
+	return;
 }
 
-function wp_directives_loader()
-{
+function wp_directives_loader() {
 	// Load the Admin page.
-	require_once plugin_dir_path(__FILE__) . '/src/admin/admin-page.php';
+	require_once plugin_dir_path( __FILE__ ) . '/src/admin/admin-page.php';
 }
-add_action('plugins_loaded', 'wp_directives_loader');
+add_action( 'plugins_loaded', 'wp_directives_loader' );
 
 /**
  * Add default settings upon activation.
  */
-function wp_directives_activate()
-{
-	add_option('wp_directives_plugin_settings', [
-		'client_side_transitions' => false,
-	]);
+function wp_directives_activate() {
+	add_option(
+		'wp_directives_plugin_settings',
+		array(
+			'client_side_transitions' => false,
+		)
+	);
 }
-register_activation_hook(__FILE__, 'wp_directives_activate');
+register_activation_hook( __FILE__, 'wp_directives_activate' );
 
 /**
  * Delete settings on uninstall.
  */
-function wp_directives_uninstall()
-{
-	delete_option('wp_directives_plugin_settings');
+function wp_directives_uninstall() {
+	delete_option( 'wp_directives_plugin_settings' );
 }
-register_uninstall_hook(__FILE__, 'wp_directives_uninstall');
+register_uninstall_hook( __FILE__, 'wp_directives_uninstall' );
 
 /**
  * Register the scripts
  */
-function wp_directives_register_scripts()
-{
+function wp_directives_register_scripts() {
 	wp_register_script(
 		'wp-directive-vendors',
-		plugins_url('build/vendors.js', __FILE__),
-		[],
+		plugins_url( 'build/vendors.js', __FILE__ ),
+		array(),
 		'1.0.0',
 		true
 	);
 	wp_register_script(
 		'wp-directive-runtime',
-		plugins_url('build/runtime.js', __FILE__),
-		['wp-directive-vendors'],
+		plugins_url( 'build/runtime.js', __FILE__ ),
+		array( 'wp-directive-vendors' ),
 		'1.0.0',
 		true
 	);
 
 	// For now we can always enqueue the runtime. We'll figure out how to
 	// conditionally enqueue directives later.
-	wp_enqueue_script('wp-directive-runtime');
+	wp_enqueue_script( 'wp-directive-runtime' );
 }
-add_action('wp_enqueue_scripts', 'wp_directives_register_scripts');
+add_action( 'wp_enqueue_scripts', 'wp_directives_register_scripts' );
 
-function wp_directives_add_wp_link_attribute($block_content)
-{
-	$site_url = parse_url(get_site_url());
-	$w = new WP_HTML_Tag_Processor($block_content);
-	while ($w->next_tag('a')) {
-		if ($w->get_attribute('target') === '_blank') {
+function wp_directives_add_wp_link_attribute( $block_content ) {
+	$site_url = parse_url( get_site_url() );
+	$w        = new WP_HTML_Tag_Processor( $block_content );
+	while ( $w->next_tag( 'a' ) ) {
+		if ( $w->get_attribute( 'target' ) === '_blank' ) {
 			break;
 		}
 
-		$link = parse_url($w->get_attribute('href'));
-		if (!isset($link['host']) || $link['host'] === $site_url['host']) {
-			$classes = $w->get_attribute('class');
-			if (str_contains($classes, 'query-pagination') || str_contains($classes, 'page-numbers')) {
-				$w->set_attribute('wp-link', '{ "prefetch": true, "scroll": false }');
+		$link = parse_url( $w->get_attribute( 'href' ) );
+		if ( ! isset( $link['host'] ) || $link['host'] === $site_url['host'] ) {
+			$classes = $w->get_attribute( 'class' );
+			if ( str_contains( $classes, 'query-pagination' ) || str_contains( $classes, 'page-numbers' ) ) {
+				$w->set_attribute( 'wp-link', '{ "prefetch": true, "scroll": false }' );
 			} else {
-				$w->set_attribute('wp-link', '{ "prefetch": true }');
+				$w->set_attribute( 'wp-link', '{ "prefetch": true }' );
 			}
 		}
 	}
 	return (string) $w;
 }
 // We go only through the Query Loops and the template parts until we find a better solution.
-add_filter('render_block_core/query', 'wp_directives_add_wp_link_attribute', 10, 1);
-add_filter('render_block_core/template-part', 'wp_directives_add_wp_link_attribute', 10, 1);
+add_filter( 'render_block_core/query', 'wp_directives_add_wp_link_attribute', 10, 1 );
+add_filter( 'render_block_core/template-part', 'wp_directives_add_wp_link_attribute', 10, 1 );
 
-function wp_directives_client_site_transitions_meta_tag()
-{
-	if (apply_filters('client_side_transitions', false)) {
+function wp_directives_client_site_transitions_meta_tag() {
+	if ( apply_filters( 'client_side_transitions', false ) ) {
 		echo '<meta itemprop="wp-client-side-transitions" content="active">';
 	}
 }
-add_action('wp_head', 'wp_directives_client_site_transitions_meta_tag', 10, 0);
+add_action( 'wp_head', 'wp_directives_client_site_transitions_meta_tag', 10, 0 );
 
 /* User code */
-function wp_directives_client_site_transitions_option()
-{
-	$options = get_option('wp_directives_plugin_settings');
+function wp_directives_client_site_transitions_option() {
+	$options = get_option( 'wp_directives_plugin_settings' );
 	return $options['client_side_transitions'];
 }
 add_filter(

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -10,6 +10,9 @@
  * Text Domain:       wp-directives
  */
 
+
+
+
 function wp_directives_loader()
 {
 	// Load the Admin page.
@@ -106,3 +109,18 @@ add_filter(
 	'client_side_transitions',
 	'wp_directives_client_site_transitions_option'
 );
+
+// Check if Gutenberg plugin is active
+if (!function_exists('is_plugin_active')) {
+    include_once(ABSPATH . 'wp-admin/includes/plugin.php');
+}
+if ( ! is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
+    // Show an error message
+    add_action( 'admin_notices', function() {
+		echo sprintf( '<div class="error"><p>%s</p></div>', __( 'This plugin requires the Gutenberg plugin to be installed and activated.', 'wp-directives' ) );
+    });
+
+    // Deactivate the plugin
+    deactivate_plugins( plugin_basename( __FILE__ ) );
+    return;
+}


### PR DESCRIPTION
## Why

Right now, in the weird case that somebody installs the directives plugin without Gutenberg, they will get a fatal error, as we are using `WP_HTML_Tag_Processor`, which is declared in that plugin.
![Screenshot 2022-12-14 at 16 33 04](https://user-images.githubusercontent.com/37012961/207641043-59218370-5b54-4ad7-854e-78da9c9c5806.jpg)

## How
With GPT-3, of course
![Screenshot 2022-12-14 at 16 39 57](https://user-images.githubusercontent.com/37012961/207641131-d1dd9901-e7cc-4db9-ba87-e026aaef440a.jpg)

## Testing

https://user-images.githubusercontent.com/37012961/207641442-f64d0d1f-5d53-4eb6-9b95-38e1468f43b9.mov

