### PR TITLE
Treat `nodeType` 7 like comments

### DIFF
--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -34,7 +34,7 @@ export default function toVdom(node) {
 	const children = [];
 	for (let i = 0; i < childNodes.length; i++) {
 		const child = childNodes[i];
-		if (child.nodeType === 8) {
+		if (child.nodeType === 8 || child.nodeType === 7) {
 			child.remove();
 			i--;
 		} else {


### PR DESCRIPTION
As explained in #117 , there are some sites using `xpacket` inside SVG nodes, which returns a hydration error. As David suggests [here](https://github.com/WordPress/block-hydration-experiments/issues/117#issuecomment-1353029764), and following [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/ProcessingInstruction), I am filling this PR to treat them like comments and removing them.

I am planning to add tests for this and other use cases in other PR.