### PR TITLE
Ignore `ref` attr while generating virtual nodes

### DIFF
--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -24,6 +24,8 @@ export default function toVdom(node) {
 			const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(n);
 			wpDirectives[prefix] = wpDirectives[prefix] || {};
 			wpDirectives[prefix][suffix || 'default'] = val;
+		} else if (n === 'ref') {
+			continue;
 		} else {
 			props[n] = attributes[i].value;
 		}


### PR DESCRIPTION
As @DAreRodz suggested [here](https://github.com/WordPress/block-hydration-experiments/issues/116#issuecomment-1352854882), I'm ignoring the `ref` attribute while generating virtual nodes. This seems to solve the hydration error that sites with `ref` attributes were returning.

I am planning to add tests for this and other use cases in other PR.