### PR TITLE
Update stress testing with handling of `ref` and `xpacket`

### DIFF
--- a/benchmark/index.mjs
+++ b/benchmark/index.mjs
@@ -227,13 +227,14 @@ async function runScript(wordPressPage, url, browser) {
 		// Save mutations in DB.
 		if (result.mutations) {
 			result.mutations.forEach(async (mutation) => {
-				const isComment =
+				const excludeMutation =
 					mutation?.addedNodes.length === 0 &&
 					mutation?.removedNodes.length === 1 &&
-					mutation?.removedNodes[0]?.nodeName === '#comment';
+					(mutation?.removedNodes[0]?.nodeName === '#comment' ||
+						mutation?.removedNodes[0]?.nodeName === 'xpacket');
 
-				// Ignore comment mutations
-				if (!isComment) {
+				// Ignore comment and nodeType 7 mutations
+				if (!excludeMutation) {
 					console.log(inspect(mutation, { colors: true, depth: 5 }));
 
 					for (let node of mutation.removedNodes) {

--- a/benchmark/manual-testing-script.js
+++ b/benchmark/manual-testing-script.js
@@ -658,6 +658,8 @@
 				const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(n);
 				wpDirectives[prefix] = wpDirectives[prefix] || {};
 				wpDirectives[prefix][suffix || 'default'] = val;
+			} else if (n === 'ref') {
+				continue;
 			} else {
 				props[n] = attributes[i2].value;
 			}
@@ -666,7 +668,7 @@
 		const children = [];
 		for (let i2 = 0; i2 < childNodes.length; i2++) {
 			const child = childNodes[i2];
-			if (child.nodeType === 8) {
+			if (child.nodeType === 8 || child.nodeType === 7) {
 				child.remove();
 				i2--;
 			} else {

--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -34,7 +34,7 @@ export default function toVdom(node) {
 	const children = [];
 	for (let i = 0; i < childNodes.length; i++) {
 		const child = childNodes[i];
-		if (child.nodeType === 8) {
+		if (child.nodeType === 8 || child.nodeType === 7) {
 			child.remove();
 			i--;
 		} else {

--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -24,6 +24,8 @@ export default function toVdom(node) {
 			const [, prefix, suffix] = /wp-([^:]+):?(.*)$/.exec(n);
 			wpDirectives[prefix] = wpDirectives[prefix] || {};
 			wpDirectives[prefix][suffix || 'default'] = val;
+		} else if (n === 'ref') {
+			continue;
 		} else {
 			props[n] = attributes[i].value;
 		}


### PR DESCRIPTION
After merging #121 and #122 , I'm applying the same changes in the stress testing branch. I basically:

- Merged the latest changes.
- Change the manual testing script.
- Prevent `xpacket` mutations from being registered in the DB.