### PR TITLE
Router: Use `window.location` to clean the URL

### DIFF
--- a/src/runtime/router.js
+++ b/src/runtime/router.js
@@ -12,7 +12,7 @@ const stylesheets = new Map();
 // Helper to remove domain and hash from the URL. We are only interesting in
 // caching the path and the query.
 const cleanUrl = (url) => {
-	const u = new URL(url, 'http://a.bc');
+	const u = new URL(url, window.location);
 	return u.pathname + u.search;
 };
 


### PR DESCRIPTION
## What

Fixes a bug in `navigate` that made relative links fail.

## Why

We were using an arbitrary URL to clean URLs.

https://github.com/WordPress/block-hydration-experiments/blob/0c2d3d9bd7673c466ada815d72bdc53889f5838e/src/runtime/router.js#L15

As that arbitrary URL didn't contain any path, the relative links of WP sites that live in a particular path (e.g., `href="all-products"` in `https://domain.example/shop/`) stopped working because the site path (`/shop/`) was not included in the final URL.

## How

Using `window.location` to calculate the URL to navigate instead of an arbitrary URL.
