### PR TITLE
Make `wp-context` inheritable and extensible

### DIFF
--- a/e2e/directives-context.html
+++ b/e2e/directives-context.html
@@ -57,6 +57,14 @@
                     <!-- rendered during hydration -->
                 </pre>
 				<button
+					data-testid="child prop1"
+					name="prop1"
+					value="modifiedFromChild"
+					wp-on:click="actions.updateContext"
+				>
+					prop1
+				</button>
+				<button
 					data-testid="child prop2"
 					name="prop2"
 					value="modifiedFromChild"
@@ -71,6 +79,14 @@
 					wp-on:click="actions.updateContext"
 				>
 					prop3
+				</button>
+				<button
+					data-testid="child obj.prop4"
+					name="obj.prop4"
+					value="modifiedFromChild"
+					wp-on:click="actions.updateContext"
+				>
+					obj.prop4
 				</button>
 				<button
 					data-testid="child obj.prop5"

--- a/e2e/directives-context.html
+++ b/e2e/directives-context.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Directives -- wp-context</title>
+		<meta itemprop="wp-client-side-transitions" content="active" />
+	</head>
+
+	<body>
+		<div
+			wp-context='{ "prop1":"parent","prop2":"parent","obj":{"prop4":"parent","prop5":"parent"},"array":[1,2,3] }'
+		>
+			<pre
+				data-testid="parent context"
+				wp-bind:children="derived.renderContext"
+			>
+                <!-- rendered during hydration -->
+            </pre>
+			<button
+				data-testid="parent prop1"
+				name="prop1"
+				value="modifiedFromParent"
+				wp-on:click="actions.updateContext"
+			>
+				prop1
+			</button>
+			<button
+				data-testid="parent prop2"
+				name="prop2"
+				value="modifiedFromParent"
+				wp-on:click="actions.updateContext"
+			>
+				prop2
+			</button>
+			<button
+				data-testid="parent obj.prop4"
+				name="obj.prop4"
+				value="modifiedFromParent"
+				wp-on:click="actions.updateContext"
+			>
+				obj.prop4
+			</button>
+			<button
+				data-testid="parent obj.prop5"
+				name="obj.prop5"
+				value="modifiedFromParent"
+				wp-on:click="actions.updateContext"
+			>
+				obj.prop5
+			</button>
+			<div
+				wp-context='{ "prop2":"child","prop3":"child","obj":{"prop5":"child","prop6":"child"},"array":[4,5,6] }'
+			>
+				<pre
+					data-testid="child context"
+					wp-bind:children="derived.renderContext"
+				>
+                    <!-- rendered during hydration -->
+                </pre>
+				<button
+					data-testid="child prop2"
+					name="prop2"
+					value="modifiedFromChild"
+					wp-on:click="actions.updateContext"
+				>
+					prop2
+				</button>
+				<button
+					data-testid="child prop3"
+					name="prop3"
+					value="modifiedFromChild"
+					wp-on:click="actions.updateContext"
+				>
+					prop3
+				</button>
+				<button
+					data-testid="child obj.prop5"
+					name="obj.prop5"
+					value="modifiedFromChild"
+					wp-on:click="actions.updateContext"
+				>
+					obj.prop5
+				</button>
+				<button
+					data-testid="child obj.prop6"
+					name="obj.prop6"
+					value="modifiedFromChild"
+					wp-on:click="actions.updateContext"
+				>
+					obj.prop6
+				</button>
+			</div>
+		</div>
+
+		<script src="../build/e2e/wpx.js"></script>
+		<script src="../build/runtime.js"></script>
+		<script src="../build/vendors.js"></script>
+	</body>
+</html>

--- a/e2e/directives-context.spec.ts
+++ b/e2e/directives-context.spec.ts
@@ -11,8 +11,8 @@ test.describe('wp-context', () => {
 
 	test('properties can be inherited', async ({ page }) => {
 		const context = page.getByTestId('child context');
-		const prop1Button = page.getByTestId('parent prop1');
-		const prop4Button = page.getByTestId('parent obj.prop4');
+		const prop1ParentButton = page.getByTestId('parent prop1');
+		const prop4ParentButton = page.getByTestId('parent obj.prop4');
 
 		// Properties from parent should be inheried.
 		{
@@ -26,8 +26,8 @@ test.describe('wp-context', () => {
 		}
 
 		// Changes in parent context should be reflected.
-		await prop1Button.click();
-		await prop4Button.click();
+		await prop1ParentButton.click();
+		await prop4ParentButton.click();
 
 		{
 			const {
@@ -35,16 +35,16 @@ test.describe('wp-context', () => {
 				obj: { prop4 },
 			} = await parseContent(context);
 
-			expect(prop1).toBe('modified');
-			expect(prop4).toBe('modified');
+			expect(prop1).toBe('modifiedFromParent');
+			expect(prop4).toBe('modifiedFromParent');
 		}
 	});
 
 	test('inherited properties can be modified', async ({ page }) => {
 		const parentContext = page.getByTestId('parent context');
 		const childContext = page.getByTestId('child context');
-		const prop1Button = page.getByTestId('child prop1');
-		const prop4Button = page.getByTestId('child obj.prop4');
+		const prop1ChildButton = page.getByTestId('child prop1');
+		const prop4ChildButton = page.getByTestId('child obj.prop4');
 
 		// Properties from parent should be inheried.
 		{
@@ -58,8 +58,8 @@ test.describe('wp-context', () => {
 		}
 
 		// Changes in child context should be reflected in parent.
-		await prop1Button.click();
-		await prop4Button.click();
+		await prop1ChildButton.click();
+		await prop4ChildButton.click();
 
 		{
 			const {
@@ -67,8 +67,8 @@ test.describe('wp-context', () => {
 				obj: { prop4 },
 			} = await parseContent(parentContext);
 
-			expect(prop1).toBe('modified');
-			expect(prop4).toBe('modified');
+			expect(prop1).toBe('modifiedFromChild');
+			expect(prop4).toBe('modifiedFromChild');
 		}
 	});
 

--- a/e2e/directives-context.spec.ts
+++ b/e2e/directives-context.spec.ts
@@ -1,0 +1,142 @@
+import { join } from 'path';
+import { test, expect, Locator } from '@playwright/test';
+
+const parseContent = async (loc: Locator) =>
+	JSON.parse((await loc.textContent()) || '');
+
+test.describe('wp-context', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('file://' + join(__dirname, 'directives-context.html'));
+	});
+
+	test('properties can be inherited', async ({ page }) => {
+		const context = page.getByTestId('child context');
+		const prop1Button = page.getByTestId('parent prop1');
+		const prop4Button = page.getByTestId('parent obj.prop4');
+
+		// Properties from parent should be inheried.
+		{
+			const {
+				prop1,
+				obj: { prop4 },
+			} = await parseContent(context);
+
+			expect(prop1).toBe('parent');
+			expect(prop4).toBe('parent');
+		}
+
+		// Changes in parent context should be reflected.
+		await prop1Button.click();
+		await prop4Button.click();
+
+		{
+			const {
+				prop1,
+				obj: { prop4 },
+			} = await parseContent(context);
+
+			expect(prop1).toBe('modified');
+			expect(prop4).toBe('modified');
+		}
+	});
+
+	test('inherited properties can be modified', async ({ page }) => {
+		const parentContext = page.getByTestId('parent context');
+		const childContext = page.getByTestId('child context');
+		const prop1Button = page.getByTestId('child prop1');
+		const prop4Button = page.getByTestId('child obj.prop4');
+
+		// Properties from parent should be inheried.
+		{
+			const {
+				prop1,
+				obj: { prop4 },
+			} = await parseContent(childContext);
+
+			expect(prop1).toBe('parent');
+			expect(prop4).toBe('parent');
+		}
+
+		// Changes in child context should be reflected in parent.
+		await prop1Button.click();
+		await prop4Button.click();
+
+		{
+			const {
+				prop1,
+				obj: { prop4 },
+			} = await parseContent(parentContext);
+
+			expect(prop1).toBe('modified');
+			expect(prop4).toBe('modified');
+		}
+	});
+
+	test('properties can be shadowed', async ({ page }) => {
+		const parentContext = page.getByTestId('parent context');
+		const childContext = page.getByTestId('child context');
+		const prop1Button = page.getByTestId('child prop2');
+		const prop4Button = page.getByTestId('child obj.prop5');
+
+		// Shadowed properties should NOT be inheried from parent.
+		{
+			const {
+				prop2,
+				obj: { prop5 },
+			} = await parseContent(childContext);
+
+			expect(prop2).toBe('child');
+			expect(prop5).toBe('child');
+		}
+
+		// Shadowed properties should NOT have changed in parent.
+		{
+			const {
+				prop2,
+				obj: { prop5 },
+			} = await parseContent(parentContext);
+
+			expect(prop2).toBe('parent');
+			expect(prop5).toBe('parent');
+		}
+
+		// Changes in shadowed context should NOT affect parent.
+		await prop1Button.click();
+		await prop4Button.click();
+
+		{
+			const {
+				prop2,
+				obj: { prop5 },
+			} = await parseContent(childContext);
+
+			expect(prop2).toBe('modifiedFromChild');
+			expect(prop5).toBe('modifiedFromChild');
+		}
+
+		{
+			const {
+				prop2,
+				obj: { prop5 },
+			} = await parseContent(parentContext);
+
+			expect(prop2).toBe('parent');
+			expect(prop5).toBe('parent');
+		}
+	});
+
+	test('array properties are shadowed', async ({ page }) => {
+		const parentContext = page.getByTestId('parent context');
+		const childContext = page.getByTestId('child context');
+
+		{
+			const { array } = await parseContent(parentContext);
+			expect(array).toMatchObject([1, 2, 3]);
+		}
+
+		{
+			const { array } = await parseContent(childContext);
+			expect(array).toMatchObject([4, 5, 6]);
+		}
+	});
+});

--- a/e2e/wpx.js
+++ b/e2e/wpx.js
@@ -5,6 +5,11 @@ wpx({
 		trueValue: true,
 		falseValue: false,
 	},
+	derived: {
+		renderContext: ({ context }) => {
+			return JSON.stringify(context, undefined, 2);
+		},
+	},
 	actions: {
 		toggleTrueValue: ({ state }) => {
 			state.trueValue = !state.trueValue;
@@ -14,6 +19,12 @@ wpx({
 		},
 		toggleContextFalseValue: ({ context }) => {
 			context.falseValue = !context.falseValue;
+		},
+		updateContext: ({ context, event }) => {
+			const { name, value } = event.target;
+			const [key, ...path] = name.split('.').reverse();
+			const obj = path.reduceRight((o, k) => o[k], context);
+			obj[key] = value;
 		},
 	},
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2567,7 +2567,7 @@
 		"@types/json5": {
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
 			"dev": true
 		},
 		"@types/keyv": {
@@ -4692,7 +4692,7 @@
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
 		},
 		"array-flatten": {
@@ -4723,7 +4723,7 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
 			"dev": true
 		},
 		"array.prototype.flat": {
@@ -4753,13 +4753,13 @@
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
 		"ast-types-flow": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-			"integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
+			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
 			"dev": true
 		},
 		"astral-regex": {
@@ -5009,7 +5009,7 @@
 		"batch": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-			"integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
+			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
 			"dev": true
 		},
 		"big.js": {
@@ -5106,7 +5106,7 @@
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -5168,7 +5168,7 @@
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
 			"dev": true
 		},
 		"buffer-from": {
@@ -5180,7 +5180,7 @@
 		"bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
 			"dev": true
 		},
 		"cacheable-lookup": {
@@ -5497,13 +5497,13 @@
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
 			"dev": true
 		},
 		"clone-deep": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
-			"integrity": "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==",
+			"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
 			"dev": true,
 			"requires": {
 				"for-own": "^0.1.3",
@@ -5544,7 +5544,7 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
 		},
 		"collect-v8-coverage": {
@@ -5565,7 +5565,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
 		"colord": {
@@ -5610,7 +5610,7 @@
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
 			"dev": true
 		},
 		"compressible": {
@@ -5649,7 +5649,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
 			}
@@ -5657,7 +5657,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
 		"concat-stream": {
@@ -5735,7 +5735,7 @@
 		"cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
 			"dev": true
 		},
 		"copy-dir": {
@@ -6063,7 +6063,7 @@
 		"cwd": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
-			"integrity": "sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==",
+			"integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
 			"dev": true,
 			"requires": {
 				"find-pkg": "^0.1.2",
@@ -6099,13 +6099,13 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
@@ -6115,7 +6115,7 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
 					"dev": true
 				}
 			}
@@ -6138,7 +6138,7 @@
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
 			"dev": true
 		},
 		"deep-extend": {
@@ -6226,7 +6226,7 @@
 				"array-union": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-					"integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 					"dev": true,
 					"requires": {
 						"array-uniq": "^1.0.1"
@@ -6235,7 +6235,7 @@
 				"globby": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-					"integrity": "sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==",
+					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
@@ -6248,7 +6248,7 @@
 						"pify": {
 							"version": "2.3.0",
 							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 							"dev": true
 						}
 					}
@@ -6318,7 +6318,7 @@
 		"dns-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-			"integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
+			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
 			"dev": true
 		},
 		"dns-packet": {
@@ -6440,7 +6440,7 @@
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
 			"dev": true
 		},
 		"electron-to-chromium": {
@@ -6470,7 +6470,7 @@
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
 			"dev": true
 		},
 		"end-of-stream": {
@@ -6589,13 +6589,13 @@
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
 			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
 		},
 		"escodegen": {
@@ -6948,7 +6948,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
 			}
@@ -7179,7 +7179,7 @@
 		"etag": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
 			"dev": true
 		},
 		"eventemitter3": {
@@ -7222,13 +7222,13 @@
 		"exit": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
 			"dev": true
 		},
 		"expand-tilde": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-			"integrity": "sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==",
+			"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
 			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.1"
@@ -7469,7 +7469,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
 			}
@@ -7508,7 +7508,7 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
 		"fastest-levenshtein": {
@@ -7547,7 +7547,7 @@
 		"fd-slicer": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
 			"dev": true,
 			"requires": {
 				"pend": "~1.2.0"
@@ -7574,7 +7574,7 @@
 		"filename-reserved-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-			"integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
 			"dev": true
 		},
 		"filenamify": {
@@ -7624,7 +7624,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
 			}
@@ -7643,7 +7643,7 @@
 		"find-file-up": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
-			"integrity": "sha512-mBxmNbVyjg1LQIIpgO8hN+ybWBgDQK8qjht+EbrTCGmmPV/sc7RF1i9stPTD6bpvXZywBdrwRYxhSdJv867L6A==",
+			"integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
 			"dev": true,
 			"requires": {
 				"fs-exists-sync": "^0.1.0",
@@ -7659,7 +7659,7 @@
 		"find-pkg": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
-			"integrity": "sha512-0rnQWcFwZr7eO0513HahrWafsc3CTFioEB7DRiEYCUM/70QXSY8f3mCST17HXLcPvEhzH/Ty/Bxd72ZZsr/yvw==",
+			"integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
 			"dev": true,
 			"requires": {
 				"find-file-up": "^0.1.2"
@@ -7768,13 +7768,13 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.1"
@@ -7806,7 +7806,7 @@
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
 			"dev": true
 		},
 		"fs-constants": {
@@ -7818,7 +7818,7 @@
 		"fs-exists-sync": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-			"integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==",
+			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
 			"dev": true
 		},
 		"fs-monkey": {
@@ -7830,7 +7830,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
 		"fsevents": {
@@ -7950,7 +7950,7 @@
 		"global-modules": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-			"integrity": "sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==",
+			"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
 			"dev": true,
 			"requires": {
 				"global-prefix": "^0.1.4",
@@ -7960,7 +7960,7 @@
 		"global-prefix": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-			"integrity": "sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==",
+			"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
 			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.0",
@@ -8003,7 +8003,7 @@
 		"globjoin": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
-			"integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+			"integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
 			"dev": true
 		},
 		"got": {
@@ -8080,7 +8080,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
 		"has-property-descriptors": {
@@ -8143,7 +8143,7 @@
 		"hpack.js": {
 			"version": "2.1.6",
 			"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-			"integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
+			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
 			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
@@ -8193,7 +8193,7 @@
 		"http-deceiver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-			"integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
+			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
 			"dev": true
 		},
 		"http-errors": {
@@ -8345,7 +8345,7 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
 			"dev": true
 		},
 		"indent-string": {
@@ -8357,7 +8357,7 @@
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
@@ -8480,7 +8480,7 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
 			"dev": true
 		},
 		"is-bigint": {
@@ -8550,13 +8550,13 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
 			"dev": true
 		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
 			"dev": true
 		},
 		"is-fullwidth-code-point": {
@@ -8695,7 +8695,7 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
 		},
 		"is-unicode-supported": {
@@ -8716,7 +8716,7 @@
 		"is-windows": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-			"integrity": "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==",
+			"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
 			"dev": true
 		},
 		"is-wsl": {
@@ -8731,19 +8731,19 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
 		},
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
@@ -11054,7 +11054,7 @@
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
 		},
 		"json2php": {
@@ -11097,7 +11097,7 @@
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"dev": true,
 			"requires": {
 				"is-buffer": "^1.1.5"
@@ -11130,7 +11130,7 @@
 		"language-tags": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
-			"integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
+			"integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
 			"dev": true,
 			"requires": {
 				"language-subtag-registry": "~0.3.2"
@@ -11139,7 +11139,7 @@
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
 			"dev": true
 		},
 		"leven": {
@@ -11220,13 +11220,13 @@
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
 			"dev": true
 		},
 		"lodash.merge": {
@@ -11238,13 +11238,13 @@
 		"lodash.truncate": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+			"integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
 			"dev": true
 		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 			"dev": true
 		},
 		"log-symbols": {
@@ -11333,7 +11333,7 @@
 		"map-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
-			"integrity": "sha512-BbShUnr5OartXJe1GeccAWtfro11hhgNJg6G9/UtWKjVGvV5U4C09cg5nk8JUevhXODaXY+hQ3xxMUKSs62ONQ==",
+			"integrity": "sha1-douOecAJvytk/ugG4ip7HEGQyZA=",
 			"dev": true
 		},
 		"markdown-it": {
@@ -11443,13 +11443,13 @@
 		"mdurl": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-			"integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
 			"dev": true
 		},
 		"media-typer": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
 			"dev": true
 		},
 		"mem": {
@@ -11522,7 +11522,7 @@
 		"merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
 			"dev": true
 		},
 		"merge-stream": {
@@ -11540,7 +11540,7 @@
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
 			"dev": true
 		},
 		"micromatch": {
@@ -11677,7 +11677,7 @@
 				"is-plain-obj": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-					"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+					"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
 					"dev": true
 				},
 				"kind-of": {
@@ -11691,7 +11691,7 @@
 		"mixin-object": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-			"integrity": "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==",
+			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
 			"dev": true,
 			"requires": {
 				"for-in": "^0.1.3",
@@ -11701,7 +11701,7 @@
 				"for-in": {
 					"version": "0.1.8",
 					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-					"integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
+					"integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
 					"dev": true
 				}
 			}
@@ -11758,7 +11758,7 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
 		"negotiator": {
@@ -11803,19 +11803,19 @@
 				"tr46": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-					"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
 					"dev": true
 				},
 				"webidl-conversions": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
 					"dev": true
 				},
 				"whatwg-url": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-					"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+					"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
 					"dev": true,
 					"requires": {
 						"tr46": "~0.0.3",
@@ -11833,7 +11833,7 @@
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
 			"dev": true
 		},
 		"node-releases": {
@@ -11871,7 +11871,7 @@
 		"normalize-range": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
 			"dev": true
 		},
 		"normalize-url": {
@@ -12027,13 +12027,13 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 			"dev": true
 		},
 		"object-filter": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
-			"integrity": "sha512-NahvP2vZcy1ZiiYah30CEPw0FpDcSkSePJBMpzl5EQgCmISijiGuJm3SPYp7U+Lf2TljyaIw3E5EgkEx/TNEVA==",
+			"integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g=",
 			"dev": true
 		},
 		"object-inspect": {
@@ -12127,7 +12127,7 @@
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
@@ -12251,13 +12251,13 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"dev": true
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
 		},
 		"p-cancelable": {
@@ -12284,7 +12284,7 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 			"dev": true
 		},
 		"p-limit": {
@@ -12378,7 +12378,7 @@
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
 			"dev": true
 		},
 		"parse5": {
@@ -12438,13 +12438,13 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
 			"dev": true
 		},
 		"path-key": {
@@ -12462,7 +12462,7 @@
 		"path-to-regexp": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
 			"dev": true
 		},
 		"path-type": {
@@ -12474,7 +12474,7 @@
 		"pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
 			"dev": true
 		},
 		"php-parser": {
@@ -12504,13 +12504,13 @@
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
 			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
 				"pinkie": "^2.0.0"
@@ -12632,7 +12632,7 @@
 		"postcss-media-query-parser": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-			"integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
+			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
 			"dev": true
 		},
 		"postcss-merge-longhand": {
@@ -12844,7 +12844,7 @@
 		"postcss-resolve-nested-selector": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
-			"integrity": "sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==",
+			"integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
 			"dev": true
 		},
 		"postcss-safe-parser": {
@@ -13007,7 +13007,7 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 			"dev": true
 		},
 		"psl": {
@@ -13342,7 +13342,7 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
 		},
 		"require-from-string": {
@@ -13360,7 +13360,7 @@
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
 			"dev": true
 		},
 		"resolve": {
@@ -13395,7 +13395,7 @@
 		"resolve-dir": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-			"integrity": "sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA==",
+			"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
 			"dev": true,
 			"requires": {
 				"expand-tilde": "^1.2.2",
@@ -13575,7 +13575,7 @@
 		"select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-			"integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
+			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
 			"dev": true
 		},
 		"selfsigned": {
@@ -13626,7 +13626,7 @@
 						"ms": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 							"dev": true
 						}
 					}
@@ -13670,7 +13670,7 @@
 		"serve-index": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-			"integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
 			"dev": true,
 			"requires": {
 				"accepts": "~1.3.4",
@@ -13694,13 +13694,13 @@
 				"depd": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-					"integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+					"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
 					"dev": true
 				},
 				"http-errors": {
 					"version": "1.6.3",
 					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-					"integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 					"dev": true,
 					"requires": {
 						"depd": "~1.1.2",
@@ -13712,13 +13712,13 @@
 				"inherits": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 					"dev": true
 				},
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				},
 				"setprototypeof": {
@@ -13730,7 +13730,7 @@
 				"statuses": {
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-					"integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+					"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
 					"dev": true
 				}
 			}
@@ -13756,7 +13756,7 @@
 		"shallow-clone": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
-			"integrity": "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==",
+			"integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
 			"dev": true,
 			"requires": {
 				"is-extendable": "^0.1.1",
@@ -13768,7 +13768,7 @@
 				"kind-of": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-					"integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
+					"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
 					"dev": true,
 					"requires": {
 						"is-buffer": "^1.0.2"
@@ -13777,7 +13777,7 @@
 				"lazy-cache": {
 					"version": "0.2.7",
 					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-					"integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
+					"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
 					"dev": true
 				}
 			}
@@ -14198,7 +14198,7 @@
 		"style-search": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
-			"integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
+			"integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
 			"dev": true
 		},
 		"stylehacks": {
@@ -14443,7 +14443,7 @@
 		"svg-tags": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
-			"integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
 			"dev": true
 		},
 		"svgo": {
@@ -14639,7 +14639,7 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
 		},
 		"throat": {
@@ -14651,7 +14651,7 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
 		"thunky": {
@@ -14678,7 +14678,7 @@
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
 			"dev": true
 		},
 		"to-readable-stream": {
@@ -14744,7 +14744,7 @@
 		"trim-repeated": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-			"integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.2"
@@ -14828,7 +14828,7 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
 		"typedarray-to-buffer": {
@@ -14905,7 +14905,7 @@
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
 			"dev": true
 		},
 		"update-browserslist-db": {
@@ -14985,13 +14985,13 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
 		},
 		"utils-merge": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
 			"dev": true
 		},
 		"uuid": {
@@ -15030,7 +15030,7 @@
 		"vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
 			"dev": true
 		},
 		"w3c-hr-time": {
@@ -15112,7 +15112,7 @@
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
@@ -15558,7 +15558,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
 		},
 		"write-file-atomic": {
@@ -15631,7 +15631,7 @@
 		"yauzl": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
 			"dev": true,
 			"requires": {
 				"buffer-crc32": "~0.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6160,9 +6160,9 @@
 			"dev": true
 		},
 		"deepsignal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.1.0.tgz",
-			"integrity": "sha512-Jzs2i44sBbJih5kUBhKZ/fLitUKizh/EVvgdfrX7Uocfwp2Jkd6+KsJkNXrZ7cO+G7FE+jyj50PjlebNvBqq7g==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.2.1.tgz",
+			"integrity": "sha512-ebphA/1YhqS96cZz1v83VX4bWt83H7LhMnx62P+cnq+irteuvtl7ptydZl89hLwUKiTOLWLgGU9bjqUyigcjag==",
 			"requires": {
 				"@preact/signals": "^1.0.0",
 				"@preact/signals-core": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@preact/signals": "^1.1.2",
-		"deepsignal": "^1.1.0",
+		"deepsignal": "^1.2.1",
 		"hpq": "^1.3.0",
 		"preact": "^10.10.6"
 	}

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -3,6 +3,7 @@ import { useSignalEffect } from '@preact/signals';
 import { deepSignal } from 'deepsignal';
 import { directive } from './hooks';
 import { prefetch, navigate, hasClientSideTransitions } from './router';
+import { mergeDeepSignals } from './wpx';
 
 // Until useSignalEffects is fixed:
 // https://github.com/preactjs/signals/issues/228
@@ -21,10 +22,17 @@ export default () => {
 				context: { default: context },
 			},
 			props: { children },
-			context: { Provider },
+			context: inherited,
 		}) => {
-			const signals = useMemo(() => deepSignal(context), [context]);
-			return <Provider value={signals}>{children}</Provider>;
+			const { Provider } = inherited;
+			const inheritedValue = useContext(inherited);
+			const value = useMemo(() => {
+				const localValue = deepSignal(context);
+				mergeDeepSignals(localValue, inheritedValue);
+				return localValue;
+			}, [context, inheritedValue]);
+
+			return <Provider value={value}>{children}</Provider>;
 		}
 	);
 

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -1,9 +1,8 @@
 import { useContext, useMemo, useEffect } from 'preact/hooks';
 import { useSignalEffect } from '@preact/signals';
-import { deepSignal } from 'deepsignal';
+import { deepSignal, peek } from 'deepsignal';
 import { directive } from './hooks';
 import { prefetch, navigate, hasClientSideTransitions } from './router';
-import { mergeDeepSignals } from './wpx';
 
 // Until useSignalEffects is fixed:
 // https://github.com/preactjs/signals/issues/228
@@ -12,6 +11,19 @@ const tick = () => new Promise((r) => raf(() => raf(r)));
 
 // Check if current page has client-side transitions enabled.
 const clientSideTransitions = hasClientSideTransitions(document.head);
+
+const isObject = (item) =>
+	item && typeof item === 'object' && !Array.isArray(item);
+
+const mergeDeepSignals = (target, source) => {
+	for (const k in source) {
+		if (typeof peek(target, k) === 'undefined') {
+			target[`$${k}`] = source[`$${k}`];
+		} else if (isObject(peek(target, k)) && isObject(peek(source, k))) {
+			mergeDeepSignals(target[`$${k}`].peek(), source[`$${k}`].peek());
+		}
+	}
+};
 
 export default () => {
 	// wp-context

--- a/src/runtime/wpx.js
+++ b/src/runtime/wpx.js
@@ -1,4 +1,4 @@
-import { deepSignal, peek } from 'deepsignal';
+import { deepSignal } from 'deepsignal';
 
 const isObject = (item) =>
 	item && typeof item === 'object' && !Array.isArray(item);
@@ -12,16 +12,6 @@ export const deepMerge = (target, source) => {
 			} else {
 				Object.assign(target, { [key]: source[key] });
 			}
-		}
-	}
-};
-
-export const mergeDeepSignals = (target, source) => {
-	for (const k in source) {
-		if (typeof peek(target, k) === 'undefined') {
-			target[`$${k}`] = source[`$${k}`];
-		} else if (isObject(peek(target, k)) && isObject(peek(source, k))) {
-			mergeDeepSignals(target[`$${k}`].peek(), source[`$${k}`].peek());
 		}
 	}
 };

--- a/src/runtime/wpx.js
+++ b/src/runtime/wpx.js
@@ -1,4 +1,4 @@
-import { deepSignal } from 'deepsignal';
+import { deepSignal, peek } from 'deepsignal';
 
 const isObject = (item) =>
 	item && typeof item === 'object' && !Array.isArray(item);
@@ -12,6 +12,16 @@ export const deepMerge = (target, source) => {
 			} else {
 				Object.assign(target, { [key]: source[key] });
 			}
+		}
+	}
+};
+
+export const mergeDeepSignals = (target, source) => {
+	for (const k in source) {
+		if (typeof peek(target, k) === 'undefined') {
+			target[`$${k}`] = source[`$${k}`];
+		} else if (isObject(peek(target, k)) && isObject(peek(source, k))) {
+			mergeDeepSignals(target[`$${k}`].peek(), source[`$${k}`].peek());
 		}
 	}
 };


### PR DESCRIPTION
## What

(Re) implement the `wp-context` directive so nested contexts can inherit properties from the parent context. Inherited properties can also be shadowed if redeclared in the child context.

## Why

At this moment, a child context replaces the parent context entirely, but contexts should be inheritable and extensible to cover most use cases. 

## How

Implementing a `mergeDeepSignals` function that copies signals from the parent context only if they're not already defined in the child context. That would allow, for example, changes in inherited properties from the child context to be reflected in the parent one, except in the case those properties are shadowed.