### PR TITLE
Implement `wp-context` attribute directive

### DIFF
--- a/phpunit/directives/attributes/wp-context.php
+++ b/phpunit/directives/attributes/wp-context.php
@@ -3,7 +3,7 @@
  * wp-context attribute directive test.
  */
 
-// require_once __DIR__ . '/../../../src/directives/attributes/wp-context.php'; // TODO
+require_once __DIR__ . '/../../../src/directives/attributes/wp-context.php';
 
 require_once __DIR__ . '/../../../src/directives/class-wp-directive-context.php';
 
@@ -17,8 +17,6 @@ require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/index.php';
  */
 class Tests_Directives_Attributes_WpContext extends WP_UnitTestCase {
 	public function test_directive_merges_context_correctly_upon_wp_context_attribute_on_opening_tag() {
-		$this->markTestSkipped( 'Need to implement the wp-context attribute directive processor first.' );
-
 		$context = new WP_Directive_Context(
 			array(
 				'myblock'    => array( 'open' => false ),
@@ -37,6 +35,27 @@ class Tests_Directives_Attributes_WpContext extends WP_UnitTestCase {
 				'myblock'    => array( 'open' => true ),
 				'otherblock' => array( 'somekey' => 'somevalue' ),
 			),
+			$context->get_context()
+		);
+	}
+
+	public function test_directive_resets_context_correctly_upon_closing_tag() {
+		$context = new WP_Directive_Context(
+			array( 'my-key' => 'original-value' )
+		);
+
+		$context->set_context(
+			array( 'my-key' => 'new-value' )
+		);
+
+		$markup = '</div>';
+		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
+
+		process_wp_context_tag( $tags, $context );
+
+		$this->assertSame(
+			array( 'my-key' => 'original-value' ),
 			$context->get_context()
 		);
 	}

--- a/phpunit/directives/tags/wp-context.php
+++ b/phpunit/directives/tags/wp-context.php
@@ -59,29 +59,4 @@ class Tests_Directives_Tags_WpContext extends WP_UnitTestCase {
 			$context->get_context()
 		);
 	}
-
-	public function test_directive_merges_context_correctly_upon_wp_context_attribute_on_opening_tag() {
-		$this->markTestSkipped( 'Need to implement the wp-context attribute directive processor first.' );
-
-		$context = new WP_Directive_Context(
-			array(
-				'myblock'    => array( 'open' => false ),
-				'otherblock' => array( 'somekey' => 'somevalue' ),
-			)
-		);
-
-		$markup = '<div wp-context=\'{ "myblock": { "open": true } }\'>';
-		$tags = new WP_HTML_Tag_Processor( $markup );
-		$tags->next_tag();
-
-		process_wp_context_tag( $tags, $context );
-
-		$this->assertSame(
-			array(
-				'myblock'    => array( 'open' => true ),
-				'otherblock' => array( 'somekey' => 'somevalue' ),
-			),
-			$context->get_context()
-		);
-	}
 }

--- a/src/directives/attributes/wp-context.php
+++ b/src/directives/attributes/wp-context.php
@@ -1,0 +1,19 @@
+<?php
+
+function process_wp_context_attribute( $tags, $context ) {
+	if ( $tags->is_tag_closer() ) {
+		$context->rewind_context();
+		return;
+	}
+
+	$value = $tags->get_attribute( 'wp-context' );
+	if ( null === $value ) {
+		// No wp-context directive.
+		return;
+	}
+
+	$new_context = json_decode( $value, true );
+	// TODO: Error handling.
+
+	$context->set_context( $new_context );
+}


### PR DESCRIPTION
Add the `wp-context` attribute directive (which we had previously only implemented as a _tag_ directive).

While handling the closing tag will require quite a bit of complex logic, I now think that that logic should go into the [`wp_process_directives` loop](https://github.com/WordPress/block-hydration-experiments/blob/bb6abaa5a4a7a01665b37544aca80636516a4431/wp-directives.php#L209-L245) rather than the individual directive processor.