### PR TITLE
SSR: Handle closing tags whose openers had an attribute directive

### DIFF
--- a/phpunit/directives/wp-process-directives.php
+++ b/phpunit/directives/wp-process-directives.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * wp_process_directives test.
+ */
+
+require_once __DIR__ . '/../../src/directives/wp-process-directives.php';
+
+require_once __DIR__ . '/../../../gutenberg/lib/experimental/html/wp-html.php';
+
+class Helper_Class {
+	function process_foo_test( $tags, $context ) {
+	}
+}
+
+/**
+ * Tests for the wp_process_directives function.
+ *
+ * @group  directives
+ * @covers wp_process_directives
+ */
+class Tests_Directives_WpProcessDirectives extends WP_UnitTestCase {
+	public function test_correctly_call_attribute_directive_processor_on_closing_tag() {
+
+		// PHPUnit cannot stub functions, only classes.
+		$test_helper = $this->createMock( Helper_Class::class );
+
+		$test_helper->expects( $this->exactly( 2 ) )
+					->method( 'process_foo_test' )
+					->with(
+						$this->callback(
+							function( $p ) {
+								return 'DIV' === $p->get_tag() && (
+									// Either this is a closing tag...
+									$p->is_tag_closer() ||
+									// ...or it is an open tag, and has the directive attribute set.
+									( ! $p->is_tag_closer() && 'abc' === $p->get_attribute( 'foo-test' ) )
+								);
+							}
+						)
+					);
+
+		$attribute_directives = array(
+			'foo-test' => array( $test_helper, 'process_foo_test' ),
+		);
+
+		$markup = '<div>Example: <div foo-test="abc"><img><span>This is a test></span><div>Here is a nested div</div></div></div>';
+		$tags   = new WP_HTML_Tag_Processor( $markup );
+		wp_process_directives( $tags, 'foo-', array(), $attribute_directives );
+	}
+}

--- a/src/directives/wp-process-directives.php
+++ b/src/directives/wp-process-directives.php
@@ -1,0 +1,79 @@
+<?php
+
+require_once __DIR__ . '/class-wp-directive-context.php';
+
+function wp_process_directives( $tags, $prefix, $tag_directives, $attribute_directives ) {
+	$context = new WP_Directive_Context;
+
+	$tag_stack = array();
+	while ( $tags->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
+		$tag_name = strtolower( $tags->get_tag() );
+		if ( array_key_exists( $tag_name, $tag_directives ) ) {
+			call_user_func( $tag_directives[ $tag_name ], $tags, $context );
+		} else {
+			// Components can't have directives (unless we change our mind about this).
+
+			// Is this a tag that closes the latest opening tag?
+			if ( $tags->is_tag_closer() ) {
+				if ( 0 === count( $tag_stack ) ) {
+					continue;
+				}
+
+				list( $latest_opening_tag_name, $attributes ) = end( $tag_stack );
+				if ( $latest_opening_tag_name === $tag_name ) {
+					array_pop( $tag_stack );
+
+					// If the matching opening tag didn't have any attribute directives,
+					// we move on.
+					if ( 0 === count( $attributes ) ) {
+						continue;
+					}
+				}
+			} else {
+				$attributes = $tags->get_attribute_names_with_prefix( $prefix );
+				$attributes = array_intersect( $attributes, array_keys( $attribute_directives ) );
+
+				// If this is an open tag, and if it either has attribute directives,
+				// or if we're inside a tag that does, take note of this tag and its attribute
+				// directives so we can call its directive processor once we encounter the
+				// matching closing tag.
+				if (
+					! is_html_void_element( $tags->get_tag() ) &&
+					( 0 !== count( $attributes ) || 0 !== count( $tag_stack ) )
+				) {
+					$tag_stack[] = array( $tag_name, $attributes );
+				}
+			}
+
+			foreach ( $attributes as $attribute ) {
+				call_user_func( $attribute_directives[ $attribute ], $tags, $context );
+			}
+		}
+	}
+
+	return $tags;
+}
+
+// TODO: Move into `WP_HTML_Tag_Processor` (or `WP_HTML_Processor`).
+// See e.g. https://github.com/WordPress/gutenberg/pull/47573.
+function is_html_void_element( $tag_name ) {
+	switch ( $tag_name ) {
+		case 'AREA':
+		case 'BASE':
+		case 'BR':
+		case 'COL':
+		case 'EMBED':
+		case 'HR':
+		case 'IMG':
+		case 'INPUT':
+		case 'LINK':
+		case 'META':
+		case 'SOURCE':
+		case 'TRACK':
+		case 'WBR':
+			return true;
+
+		default:
+			return false;
+	}
+}


### PR DESCRIPTION
Some attribute directives (such as `wp-context`, see #143), need to be run not only on an opening tag (e.g. `<div wp-context="...">` but also on the matching closing one. (For `wp-context`, this is required to reset the context to the value that corresponds to the enclosing scope's context.)

This needs somewhat complex logic to keep track of nested tags. Consider e.g. the following example (used in this PR's unit test):

```html
<div>Example: 
	<div foo-test="abc">
		<img>
		<span>This is a test></span>
		<div>Here is a nested div</div>
	</div>
</div>
```

Here, we want to run the `foo-test` attribute directive processor on the closing `</div>` that matches the opening `<div foo-test="abc">` -- but not on any of the other two closing `</div>`s.

Rather than requiring individual directive processors to implement the required tracking of nested tags, we implement it in the `wp_process_directives` function.

To that end, this PR also moves it into a separate file and changes its signature a bit for better testability. Finally, we're adding a unit test to verify the behavior described above.
