### PR TITLE
Serialize store in PHP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 /test-results/
 /playwright-report/
 /playwright/.cache/
+.phpunit.result.cache

--- a/e2e/directives-class.html
+++ b/e2e/directives-class.html
@@ -66,7 +66,7 @@
 			</button>
 		</wp-context>
 
-		<script src="../build/e2e/wpx.js"></script>
+		<script src="../build/e2e/store.js"></script>
 		<script src="../build/runtime.js"></script>
 		<script src="../build/vendors.js"></script>
 	</body>

--- a/e2e/directives-context.html
+++ b/e2e/directives-context.html
@@ -107,7 +107,7 @@
 			</div>
 		</div>
 
-		<script src="../build/e2e/wpx.js"></script>
+		<script src="../build/e2e/store.js"></script>
 		<script src="../build/runtime.js"></script>
 		<script src="../build/vendors.js"></script>
 	</body>

--- a/e2e/store-tag-corrupted-json.html
+++ b/e2e/store-tag-corrupted-json.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<title>Store -- hydration</title>
-		<meta itemprop="wp-client-side-transitions" content="active" />
+		<meta itemprop="wp-client-side-navigation" content="active" />
 	</head>
 
 	<body>

--- a/e2e/store-tag-corrupted-json.html
+++ b/e2e/store-tag-corrupted-json.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Store -- hydration</title>
+		<meta itemprop="wp-client-side-transitions" content="active" />
+	</head>
+
+	<body>
+		<div>
+			Counter:
+			<span
+				wp-bind:children="state.counter.value"
+				data-testid="counter value"
+				>3</span
+			>
+			<br />
+			Double:
+			<span
+				wp-bind:children="state.counter.double"
+				data-testid="counter double"
+				>6</span
+			>
+			<br />
+			<button
+				wp-on:click="actions.counter.increment"
+				data-testid="counter button"
+			>
+				+1
+			</button>
+			<span
+				wp-bind:children="state.counter.clicks"
+				data-testid="counter clicks"
+				>0</span
+			>
+			clicks
+		</div>
+		<script type="application/json" id="store">
+			this is not a JSON
+		</script>
+		<script src="../build/e2e/store.js"></script>
+		<script src="../build/runtime.js"></script>
+		<script src="../build/vendors.js"></script>
+	</body>
+</html>

--- a/e2e/store-tag-invalid-state.html
+++ b/e2e/store-tag-invalid-state.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<title>Store -- hydration</title>
-		<meta itemprop="wp-client-side-transitions" content="active" />
+		<meta itemprop="wp-client-side-navigation" content="active" />
 	</head>
 
 	<body>

--- a/e2e/store-tag-invalid-state.html
+++ b/e2e/store-tag-invalid-state.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Store -- hydration</title>
+		<meta itemprop="wp-client-side-transitions" content="active" />
+	</head>
+
+	<body>
+		<div>
+			Counter:
+			<span
+				wp-bind:children="state.counter.value"
+				data-testid="counter value"
+				>3</span
+			>
+			<br />
+			Double:
+			<span
+				wp-bind:children="state.counter.double"
+				data-testid="counter double"
+				>6</span
+			>
+			<br />
+			<button
+				wp-on:click="actions.counter.increment"
+				data-testid="counter button"
+			>
+				+1
+			</button>
+			<span
+				wp-bind:children="state.counter.clicks"
+				data-testid="counter clicks"
+				>0</span
+			>
+			clicks
+		</div>
+		<script type="application/json" id="store">
+			{ "state": null }
+		</script>
+		<script src="../build/e2e/store.js"></script>
+		<script src="../build/runtime.js"></script>
+		<script src="../build/vendors.js"></script>
+	</body>
+</html>

--- a/e2e/store-tag-missing.html
+++ b/e2e/store-tag-missing.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Store -- hydration</title>
+		<meta itemprop="wp-client-side-transitions" content="active" />
+	</head>
+
+	<body>
+		<div>
+			Counter:
+			<span
+				wp-bind:children="state.counter.value"
+				data-testid="counter value"
+				>3</span
+			>
+			<br />
+			Double:
+			<span
+				wp-bind:children="state.counter.double"
+				data-testid="counter double"
+				>6</span
+			>
+			<br />
+			<button
+				wp-on:click="actions.counter.increment"
+				data-testid="counter button"
+			>
+				+1
+			</button>
+			<span
+				wp-bind:children="state.counter.clicks"
+				data-testid="counter clicks"
+				>0</span
+			>
+			clicks
+		</div>
+		<script src="../build/e2e/store.js"></script>
+		<script src="../build/runtime.js"></script>
+		<script src="../build/vendors.js"></script>
+	</body>
+</html>

--- a/e2e/store-tag-missing.html
+++ b/e2e/store-tag-missing.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<title>Store -- hydration</title>
-		<meta itemprop="wp-client-side-transitions" content="active" />
+		<meta itemprop="wp-client-side-navigation" content="active" />
 	</head>
 
 	<body>

--- a/e2e/store-tag-ok.html
+++ b/e2e/store-tag-ok.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<title>Store -- hydration</title>
-		<meta itemprop="wp-client-side-transitions" content="active" />
+		<meta itemprop="wp-client-side-navigation" content="active" />
 	</head>
 
 	<body>

--- a/e2e/store-tag-ok.html
+++ b/e2e/store-tag-ok.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Store -- hydration</title>
+		<meta itemprop="wp-client-side-transitions" content="active" />
+	</head>
+
+	<body>
+		<div>
+			Counter:
+			<span
+				wp-bind:children="state.counter.value"
+				data-testid="counter value"
+				>3</span
+			>
+			<br />
+			Double:
+			<span
+				wp-bind:children="state.counter.double"
+				data-testid="counter double"
+				>6</span
+			>
+			<br />
+			<button
+				wp-on:click="actions.counter.increment"
+				data-testid="counter button"
+			>
+				+1
+			</button>
+			<span
+				wp-bind:children="state.counter.clicks"
+				data-testid="counter clicks"
+				>0</span
+			>
+			clicks
+		</div>
+		<script type="application/json" id="store">
+			{ "state": { "counter": { "value": 3, "double": 6 } } }
+		</script>
+		<script src="../build/e2e/store.js"></script>
+		<script src="../build/runtime.js"></script>
+		<script src="../build/vendors.js"></script>
+	</body>
+</html>

--- a/e2e/store-tag.spec.ts
+++ b/e2e/store-tag.spec.ts
@@ -1,0 +1,54 @@
+import { join } from 'path';
+import { test, expect } from '@playwright/test';
+
+test.describe('store tag', () => {
+	test('hydrates when it is well defined', async ({ page }) => {
+		await page.goto('file://' + join(__dirname, 'store-tag-ok.html'));
+		const value = page.getByTestId('counter value');
+		const double = page.getByTestId('counter double');
+		const clicks = page.getByTestId('counter clicks');
+
+		await expect(value).toHaveText('3');
+		await expect(double).toHaveText('6');
+		await expect(clicks).toHaveText('0');
+
+		page.getByTestId('counter button').click();
+
+		await expect(value).toHaveText('4');
+		await expect(double).toHaveText('8');
+		await expect(clicks).toHaveText('1');
+	});
+
+	test('does not break the page when missing', async ({ page }) => {
+		await page.goto('file://' + join(__dirname, 'store-tag-missing.html'));
+
+		const clicks = page.getByTestId('counter clicks');
+		await expect(clicks).toHaveText('0');
+		page.getByTestId('counter button').click();
+		await expect(clicks).toHaveText('1');
+	});
+
+	test('does not break the page when corrupted', async ({ page }) => {
+		await page.goto(
+			'file://' + join(__dirname, 'store-tag-corrupted-json.html')
+		);
+
+		const clicks = page.getByTestId('counter clicks');
+		await expect(clicks).toHaveText('0');
+		page.getByTestId('counter button').click();
+		await expect(clicks).toHaveText('1');
+	});
+
+	test('does not break the page when it contains an invalid state', async ({
+		page,
+	}) => {
+		await page.goto(
+			'file://' + join(__dirname, 'store-tag-invalid-state.html')
+		);
+
+		const clicks = page.getByTestId('counter clicks');
+		await expect(clicks).toHaveText('0');
+		page.getByTestId('counter button').click();
+		await expect(clicks).toHaveText('1');
+	});
+});

--- a/e2e/store.js
+++ b/e2e/store.js
@@ -1,4 +1,4 @@
-import { store } from '../src/runtime';
+import { store } from '../src/runtime/store';
 
 store({
 	state: {
@@ -25,6 +25,26 @@ store({
 			const [key, ...path] = name.split('.').reverse();
 			const obj = path.reduceRight((o, k) => o[k], context);
 			obj[key] = value;
+		},
+	},
+});
+
+// State for the store hydration tests.
+store({
+	state: {
+		counter: {
+			// TODO: replace this with a getter.
+			// `value` is defined in the server.
+			double: ({ state }) => state.counter.value * 2,
+			clicks: 0,
+		},
+	},
+	actions: {
+		counter: {
+			increment: ({ state }) => {
+				state.counter.value += 1;
+				state.counter.clicks += 1;
+			},
 		},
 	},
 });

--- a/e2e/store.js
+++ b/e2e/store.js
@@ -1,6 +1,6 @@
-import { wpx } from '../src/runtime/wpx';
+import { store } from '../src/runtime';
 
-wpx({
+store({
 	state: {
 		trueValue: true,
 		falseValue: false,

--- a/e2e/tovdom-full.html
+++ b/e2e/tovdom-full.html
@@ -13,7 +13,7 @@
 			</wp-show>
 		</div>
 
-		<script src="../build/e2e/wpx.js"></script>
+		<script src="../build/e2e/store.js"></script>
 		<script src="../build/runtime.js"></script>
 		<script src="../build/vendors.js"></script>
 	</body>

--- a/e2e/tovdom-islands.html
+++ b/e2e/tovdom-islands.html
@@ -63,7 +63,7 @@
 			</div>
 		</div>
 
-		<script src="../build/e2e/wpx.js"></script>
+		<script src="../build/e2e/store.js"></script>
 		<script src="../build/runtime.js"></script>
 		<script src="../build/vendors.js"></script>
 	</body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2035,19 +2035,19 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.29.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.0.tgz",
-			"integrity": "sha512-gp5PVBenxTJsm2bATWDNc2CCnrL5OaA/MXQdJwwkGQtqTjmY+ZOqAdLqo49O9MLTDh2vYh+tHWDnmFsILnWaeA==",
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0.tgz",
+			"integrity": "sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
-				"playwright-core": "1.29.0"
+				"playwright-core": "1.30.0"
 			},
 			"dependencies": {
 				"playwright-core": {
-					"version": "1.29.0",
-					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.0.tgz",
-					"integrity": "sha512-pboOm1m0RD6z1GtwAbEH60PYRfF87vKdzOSRw2RyO0Y0a7utrMyWN2Au1ojGvQr4umuBMODkKTv607YIRypDSQ==",
+					"version": "1.30.0",
+					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
+					"integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==",
 					"dev": true
 				}
 			}
@@ -2132,17 +2132,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.2.2.tgz",
 			"integrity": "sha512-z3/bCj7rRA21RJb4FeJ4guCrD1CQbaURHkCTunUWQpxUMAFOPXCD8tSFqERyGrrcSb4T3Hrmdc1OAl0LXBHwiw=="
-		},
-		"@prettier/plugin-php": {
-			"version": "0.18.9",
-			"resolved": "https://registry.npmjs.org/@prettier/plugin-php/-/plugin-php-0.18.9.tgz",
-			"integrity": "sha512-d1uE9v3JsQ9uBLWlssZhO02RLI8u8jRBFPCO5ud4VbveCpSZbDRnGpSuK3IqSWHdM/OnuySz0yWr5M9/9mINvw==",
-			"dev": true,
-			"requires": {
-				"linguist-languages": "^7.21.0",
-				"mem": "^8.0.0",
-				"php-parser": "3.1.0-beta.11"
-			}
 		},
 		"@sideway/address": {
 			"version": "4.1.4",
@@ -11174,12 +11163,6 @@
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true
 		},
-		"linguist-languages": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-7.21.0.tgz",
-			"integrity": "sha512-KrWJJbFOvlDhjlt5OhUipVlXg+plUfRurICAyij1ZVxQcqPt/zeReb9KiUVdGUwwhS/2KS9h3TbyfYLA5MDlxQ==",
-			"dev": true
-		},
 		"linkify-it": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
@@ -11319,15 +11302,6 @@
 				"tmpl": "1.0.5"
 			}
 		},
-		"map-age-cleaner": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-			"dev": true,
-			"requires": {
-				"p-defer": "^1.0.0"
-			}
-		},
 		"map-obj": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
@@ -11456,16 +11430,6 @@
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
 			"dev": true
 		},
-		"mem": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
-			"integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
-			"dev": true,
-			"requires": {
-				"map-age-cleaner": "^0.1.3",
-				"mimic-fn": "^3.1.0"
-			}
-		},
 		"memfs": {
 			"version": "3.4.7",
 			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.7.tgz",
@@ -11577,12 +11541,6 @@
 			"requires": {
 				"mime-db": "1.52.0"
 			}
-		},
-		"mimic-fn": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-			"integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-			"dev": true
 		},
 		"mimic-response": {
 			"version": "1.0.1",
@@ -12270,12 +12228,6 @@
 			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
 			"dev": true
 		},
-		"p-defer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
-			"dev": true
-		},
 		"p-limit": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -12455,12 +12407,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
 			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-			"dev": true
-		},
-		"php-parser": {
-			"version": "3.1.0-beta.11",
-			"resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.1.0-beta.11.tgz",
-			"integrity": "sha512-aKhWHXun6FKa0MX+GcJtEoLPSWuGQTiEkNgckVjT95OAnKG33c+zsDQEpXx4R74PQ030YZLNq9XV7odKapbOsg==",
 			"dev": true
 		},
 		"picocolors": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
 		"@babel/core": "^7.17.10",
 		"@babel/preset-env": "^7.17.10",
 		"@playwright/test": "^1.29.0",
-		"@prettier/plugin-php": "^0.18.9",
 		"@types/jest": "^27.5.1",
 		"@wordpress/env": "^5.8.0",
 		"@wordpress/scripts": "^24.3.0",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,38 +2,40 @@
 <ruleset name="WordPress Coding Standards for Gutenberg Plugin">
 	<description>Sniffs for WordPress plugins, with minor modifications for Gutenberg</description>
 
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="5.6-" />
 	<rule ref="PHPCompatibilityWP">
 		<include-pattern>*\.php$</include-pattern>
 	</rule>
 
-	<rule ref="WordPress-Core"/>
-	<rule ref="WordPress-Docs"/>
-	<rule ref="WordPress.WP.I18n"/>
-	<config name="text_domain" value="gutenberg,default"/>
+	<rule ref="WordPress-Core" />
+	<rule ref="WordPress-Docs" />
+	<rule ref="WordPress.WP.I18n" />
+	<config name="text_domain" value="gutenberg,default" />
 
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
 		<properties>
-			<property name="allowUnusedParametersBeforeUsed" value="true"/>
+			<property name="allowUnusedParametersBeforeUsed" value="true" />
 		</properties>
 	</rule>
-	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
+	<rule ref="WordPress.CodeAnalysis.EmptyStatement" />
 
 	<rule ref="PEAR.Functions.FunctionCallSignature">
 		<properties>
-			<property name="allowMultipleArguments" value="false"/>
+			<property name="allowMultipleArguments" value="false" />
 		</properties>
 	</rule>
 
 	<rule ref="WordPress.WP.I18n.MissingArgDomainDefault">
-		<exclude-pattern>packages/block-library/src/*</exclude-pattern>
+		<exclude-pattern>
+			packages/block-library/src/*</exclude-pattern>
 	</rule>
 
-	<arg value="ps"/>
-	<arg name="extensions" value="php"/>
+	<arg value="ps" />
+	<arg name="extensions" value="php" />
 
 	<file>./wp-directives.php</file>
 	<file>./src</file>
+	<file>./phpunit</file>
 
 	<!-- Exclude generated files -->
 	<exclude-pattern>./build</exclude-pattern>

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -57,7 +57,7 @@ define( 'GUTENBERG_LOAD_VENDOR_SCRIPTS', false );
  * Manually load the plugin being tested.
  */
 // function _manually_load_plugin() {
-// 	require dirname( __DIR__ ) . '/lib/load.php';
+// require dirname( __DIR__ ) . '/lib/load.php';
 // }
 // tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/phpunit/directives/attributes/wp-bind.php
+++ b/phpunit/directives/attributes/wp-bind.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../src/directives/attributes/wp-bind.php';
 
 require_once __DIR__ . '/../../../src/directives/class-wp-directive-context.php';
 
-require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/index.php';
+require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/wp-html.php';
 
 /**
  * Tests for the wp-bind directive.

--- a/phpunit/directives/attributes/wp-bind.php
+++ b/phpunit/directives/attributes/wp-bind.php
@@ -18,11 +18,11 @@ require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/index.php';
 class Tests_Directives_WpBind extends WP_UnitTestCase {
 	public function test_directive_sets_attribute() {
 		$markup = '<img wp-bind:src="context.myblock.imageSource" />';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
 		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'imageSource' => './wordpress.png' ) ) );
-		$context = $context_before;
+		$context        = $context_before;
 		process_wp_bind( $tags, $context );
 
 		$this->assertSame(
@@ -35,11 +35,11 @@ class Tests_Directives_WpBind extends WP_UnitTestCase {
 
 	public function test_directive_ignores_empty_bound_attribute() {
 		$markup = '<img wp-bind:="context.myblock.imageSource" />';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
 		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'imageSource' => './wordpress.png' ) ) );
-		$context = $context_before;
+		$context        = $context_before;
 		process_wp_bind( $tags, $context );
 
 		$this->assertSame( $markup, $tags->get_updated_html() );

--- a/phpunit/directives/attributes/wp-class.php
+++ b/phpunit/directives/attributes/wp-class.php
@@ -18,11 +18,11 @@ require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/index.php';
 class Tests_Directives_WpClass extends WP_UnitTestCase {
 	public function test_directive_adds_class() {
 		$markup = '<div wp-class:red="context.myblock.isRed" class="blue">Test</div>';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
 		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'isRed' => true ) ) );
-		$context = $context_before;
+		$context        = $context_before;
 		process_wp_class( $tags, $context );
 
 		$this->assertSame(
@@ -35,11 +35,11 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 
 	public function test_directive_removes_class() {
 		$markup = '<div wp-class:blue="context.myblock.isBlue" class="red blue">Test</div>';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
 		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'isBlue' => false ) ) );
-		$context = $context_before;
+		$context        = $context_before;
 		process_wp_class( $tags, $context );
 
 		$this->assertSame(
@@ -52,11 +52,11 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 
 	public function test_directive_removes_empty_class_attribute() {
 		$markup = '<div wp-class:blue="context.myblock.isBlue" class="blue">Test</div>';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
 		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'isBlue' => false ) ) );
-		$context = $context_before;
+		$context        = $context_before;
 		process_wp_class( $tags, $context );
 
 		$this->assertSame(
@@ -70,11 +70,11 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 
 	public function test_directive_does_not_remove_non_existant_class() {
 		$markup = '<div wp-class:blue="context.myblock.isBlue" class="green red">Test</div>';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
 		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'isBlue' => false ) ) );
-		$context = $context_before;
+		$context        = $context_before;
 		process_wp_class( $tags, $context );
 
 		$this->assertSame(
@@ -87,11 +87,11 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 
 	public function test_directive_ignores_empty_class_name() {
 		$markup = '<div wp-class:="context.myblock.isRed" class="blue">Test</div>';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
 		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'isRed' => true ) ) );
-		$context = $context_before;
+		$context        = $context_before;
 		process_wp_class( $tags, $context );
 
 		$this->assertSame( $markup, $tags->get_updated_html() );

--- a/phpunit/directives/attributes/wp-class.php
+++ b/phpunit/directives/attributes/wp-class.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../src/directives/attributes/wp-class.php';
 
 require_once __DIR__ . '/../../../src/directives/class-wp-directive-context.php';
 
-require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/index.php';
+require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/wp-html.php';
 
 /**
  * Tests for the wp-class directive.

--- a/phpunit/directives/attributes/wp-context.php
+++ b/phpunit/directives/attributes/wp-context.php
@@ -27,7 +27,7 @@ class Tests_Directives_Attributes_WpContext extends WP_UnitTestCase {
 		);
 
 		$markup = '<div wp-context=\'{ "myblock": { "open": true } }\'>';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
 		process_wp_context_attribute( $tags, $context );

--- a/phpunit/directives/attributes/wp-context.php
+++ b/phpunit/directives/attributes/wp-context.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../src/directives/attributes/wp-context.php';
 
 require_once __DIR__ . '/../../../src/directives/class-wp-directive-context.php';
 
-require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/index.php';
+require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/wp-html.php';
 
 /**
  * Tests for the wp-context attribute directive.
@@ -49,7 +49,7 @@ class Tests_Directives_Attributes_WpContext extends WP_UnitTestCase {
 		);
 
 		$markup = '</div>';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
 
 		process_wp_context_tag( $tags, $context );

--- a/phpunit/directives/attributes/wp-style.php
+++ b/phpunit/directives/attributes/wp-style.php
@@ -18,11 +18,11 @@ require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/index.php';
 class Tests_Directives_WpStyle extends WP_UnitTestCase {
 	public function test_directive_adds_style() {
 		$markup = '<div wp-style:color="context.myblock.color" style="background: blue;">Test</div>';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
 		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'color' => 'green' ) ) );
-		$context = $context_before;
+		$context        = $context_before;
 		process_wp_style( $tags, $context );
 
 		$this->assertSame(
@@ -35,11 +35,11 @@ class Tests_Directives_WpStyle extends WP_UnitTestCase {
 
 	public function test_directive_ignores_empty_style() {
 		$markup = '<div wp-style:="context.myblock.color" style="background: blue;">Test</div>';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
 		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'color' => 'green' ) ) );
-		$context = $context_before;
+		$context        = $context_before;
 		process_wp_style( $tags, $context );
 
 		$this->assertSame( $markup, $tags->get_updated_html() );

--- a/phpunit/directives/attributes/wp-style.php
+++ b/phpunit/directives/attributes/wp-style.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../src/directives/attributes/wp-style.php';
 
 require_once __DIR__ . '/../../../src/directives/class-wp-directive-context.php';
 
-require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/index.php';
+require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/wp-html.php';
 
 /**
  * Tests for the wp-style directive.

--- a/phpunit/directives/tags/wp-context.php
+++ b/phpunit/directives/tags/wp-context.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../src/directives/tags/wp-context.php';
 
 require_once __DIR__ . '/../../../src/directives/class-wp-directive-context.php';
 
-require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/index.php';
+require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/wp-html.php';
 
 /**
  * Tests for the wp-context tag directive.

--- a/phpunit/directives/tags/wp-context.php
+++ b/phpunit/directives/tags/wp-context.php
@@ -25,7 +25,7 @@ class Tests_Directives_Tags_WpContext extends WP_UnitTestCase {
 		);
 
 		$markup = '<wp-context data=\'{ "myblock": { "open": true } }\'>';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
 		process_wp_context_tag( $tags, $context );
@@ -49,7 +49,7 @@ class Tests_Directives_Tags_WpContext extends WP_UnitTestCase {
 		);
 
 		$markup = '</wp-context>';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
 
 		process_wp_context_tag( $tags, $context );
@@ -71,7 +71,7 @@ class Tests_Directives_Tags_WpContext extends WP_UnitTestCase {
 		);
 
 		$markup = '<div wp-context=\'{ "myblock": { "open": true } }\'>';
-		$tags = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
 		process_wp_context_tag( $tags, $context );

--- a/phpunit/directives/utils/evaluate.php
+++ b/phpunit/directives/utils/evaluate.php
@@ -18,11 +18,11 @@ class Tests_Utils_Evaluate extends WP_UnitTestCase {
 			array(
 				'state' => array(
 					'core' => array(
-						'a' => 1,
-						'b' => 2,
+						'a'      => 1,
+						'b'      => 2,
 						'nested' => array(
-							'c' => 3
-						)
+							'c' => 3,
+						),
 					),
 				),
 			)
@@ -34,14 +34,14 @@ class Tests_Utils_Evaluate extends WP_UnitTestCase {
 	public function test_evaluate_function_should_access_passed_context() {
 		$context = array(
 			'core' => array(
-				'a' => 1,
-				'b' => 2,
+				'a'      => 1,
+				'b'      => 2,
 				'nested' => array(
-					'c' => 3
-				)
+					'c' => 3,
+				),
 			),
 		);
-		
+
 		$this->assertSame( 1, evaluate( 'context.core.a', $context ) );
 		$this->assertSame( 2, evaluate( 'context.core.b', $context ) );
 		$this->assertSame( 3, evaluate( 'context.core.nested.c', $context ) );

--- a/phpunit/directives/utils/evaluate.php
+++ b/phpunit/directives/utils/evaluate.php
@@ -18,36 +18,36 @@ class Tests_Utils_Evaluate extends WP_UnitTestCase {
 			array(
 				'state' => array(
 					'core' => array(
-						'a'      => 1,
-						'b'      => 2,
+						'number' => 1,
+						'bool'   => true,
 						'nested' => array(
-							'c' => 3,
+							'string' => 'hi',
 						),
 					),
 				),
 			)
 		);
-		$this->assertSame( 1, evaluate( 'state.core.a' ) );
-		$this->assertSame( 2, evaluate( 'state.core.b' ) );
-		$this->assertSame( 3, evaluate( 'state.core.nested.c' ) );
+		$this->assertSame( 1, evaluate( 'state.core.number' ) );
+		$this->assertTrue( evaluate( 'state.core.bool' ) );
+		$this->assertSame( 'hi', evaluate( 'state.core.nested.string' ) );
 	}
 	public function test_evaluate_function_should_access_passed_context() {
 		$context = array(
-			'core' => array(
-				'a'      => 1,
-				'b'      => 2,
+			'local' => array(
+				'number' => 2,
+				'bool'   => false,
 				'nested' => array(
-					'c' => 3,
+					'string' => 'bye',
 				),
 			),
 		);
-		$this->assertSame( 1, evaluate( 'context.core.a', $context ) );
-		$this->assertSame( 2, evaluate( 'context.core.b', $context ) );
-		$this->assertSame( 3, evaluate( 'context.core.nested.c', $context ) );
+		$this->assertSame( 2, evaluate( 'context.local.number', $context ) );
+		$this->assertFalse( evaluate( 'context.local.bool', $context ) );
+		$this->assertSame( 'bye', evaluate( 'context.local.nested.string', $context ) );
 		// Previous defined state is also accessible.
-		$this->assertSame( 1, evaluate( 'state.core.a' ) );
-		$this->assertSame( 2, evaluate( 'state.core.b' ) );
-		$this->assertSame( 3, evaluate( 'state.core.nested.c' ) );
+		$this->assertSame( 1, evaluate( 'state.core.number' ) );
+		$this->assertTrue( evaluate( 'state.core.bool' ) );
+		$this->assertSame( 'hi', evaluate( 'state.core.nested.string' ) );
 	}
 
 	public function test_evaluate_function_should_return_null_for_unresolved_paths() {

--- a/phpunit/directives/utils/evaluate.php
+++ b/phpunit/directives/utils/evaluate.php
@@ -41,10 +41,13 @@ class Tests_Utils_Evaluate extends WP_UnitTestCase {
 				),
 			),
 		);
-
 		$this->assertSame( 1, evaluate( 'context.core.a', $context ) );
 		$this->assertSame( 2, evaluate( 'context.core.b', $context ) );
 		$this->assertSame( 3, evaluate( 'context.core.nested.c', $context ) );
+		// Previous defined state is also accessible.
+		$this->assertSame( 1, evaluate( 'state.core.a' ) );
+		$this->assertSame( 2, evaluate( 'state.core.b' ) );
+		$this->assertSame( 3, evaluate( 'state.core.nested.c' ) );
 	}
 
 	public function test_evaluate_function_should_return_null_for_unresolved_paths() {

--- a/phpunit/directives/utils/evaluate.php
+++ b/phpunit/directives/utils/evaluate.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * `evaluate` function test.
+ */
+
+require_once __DIR__ . '/../../../src/directives/utils.php';
+
+/**
+ * Tests for the `evaluate` function.
+ *
+ * @group  utils
+ * @covers evaluate
+ */
+class Tests_Utils_Evaluate extends WP_UnitTestCase {
+	public function test_evaluate_function_should_access_state() {
+		// Init a simple store.
+		store(
+			array(
+				'state' => array(
+					'core' => array(
+						'a' => 1,
+						'b' => 2,
+						'nested' => array(
+							'c' => 3
+						)
+					),
+				),
+			)
+		);
+		$this->assertSame( 1, evaluate( 'state.core.a' ) );
+		$this->assertSame( 2, evaluate( 'state.core.b' ) );
+		$this->assertSame( 3, evaluate( 'state.core.nested.c' ) );
+	}
+	public function test_evaluate_function_should_access_passed_context() {
+		$context = array(
+			'core' => array(
+				'a' => 1,
+				'b' => 2,
+				'nested' => array(
+					'c' => 3
+				)
+			),
+		);
+		
+		$this->assertSame( 1, evaluate( 'context.core.a', $context ) );
+		$this->assertSame( 2, evaluate( 'context.core.b', $context ) );
+		$this->assertSame( 3, evaluate( 'context.core.nested.c', $context ) );
+	}
+
+	public function test_evaluate_function_should_return_null_for_unresolved_paths() {
+		$this->assertNull( evaluate( 'this.property.doesnt.exist' ) );
+	}
+}

--- a/phpunit/directives/wp-directive-store.php
+++ b/phpunit/directives/wp-directive-store.php
@@ -107,7 +107,7 @@ class Tests_Directives_WPDirectiveStore extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_store_should_be_correctly_render() {
+	public function test_store_should_be_correctly_rendered() {
 		WP_Directive_Store::merge_data(
 			array(
 				'state' => array(

--- a/phpunit/directives/wp-directive-store.php
+++ b/phpunit/directives/wp-directive-store.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * `WP_Directive_Store` class test.
+ */
+
+require_once __DIR__ . '/../../src/directives/utils.php';
+require_once __DIR__ . '/../../src/directives/class-wp-directive-store.php';
+
+/**
+ * Tests for the `WP_Directive_Store` class.
+ *
+ * @group  directives
+ * @covers WP_Directive_Store
+ */
+class Tests_Directives_WPDirectiveStore extends WP_UnitTestCase {
+	public function set_up() {
+		// Clear the state before each test.
+		WP_Directive_Store::reset();
+	}
+
+	public function test_store_should_be_empty() {
+		$this->assertEmpty( WP_Directive_Store::get_data() );
+	}
+
+	public function test_store_can_be_merged() {
+		$data = array(
+			'state' => array(
+				'core' => array(
+					'a'      => 1,
+					'b'      => 2,
+					'nested' => array(
+						'c' => 3,
+					),
+				),
+			),
+		);
+		WP_Directive_Store::merge_data( $data );
+		$this->assertSame( $data, WP_Directive_Store::get_data() );
+	}
+
+	public function test_store_can_be_extended() {
+		WP_Directive_Store::merge_data(
+			array(
+				'state' => array(
+					'core' => array(
+						'a' => 1,
+					),
+				),
+			)
+		);
+		WP_Directive_Store::merge_data(
+			array(
+				'state' => array(
+					'core'   => array(
+						'b' => 2,
+					),
+					'custom' => array(
+						'c' => 3,
+					),
+				),
+			)
+		);
+		$this->assertSame(
+			array(
+				'state' => array(
+					'core'   => array(
+						'a' => 1,
+						'b' => 2,
+					),
+					'custom' => array(
+						'c' => 3,
+					),
+				),
+			),
+			WP_Directive_Store::get_data()
+		);
+	}
+
+	public function test_store_existing_props_should_be_overwritten() {
+		WP_Directive_Store::merge_data(
+			array(
+				'state' => array(
+					'core' => array(
+						'a' => 1,
+					),
+				),
+			)
+		);
+		WP_Directive_Store::merge_data(
+			array(
+				'state' => array(
+					'core' => array(
+						'a' => 'overwritten',
+					),
+				),
+			)
+		);
+		$this->assertSame(
+			array(
+				'state' => array(
+					'core' => array(
+						'a' => 'overwritten',
+					),
+				),
+			),
+			WP_Directive_Store::get_data()
+		);
+	}
+
+	public function test_store_should_be_correctly_render() {
+		WP_Directive_Store::merge_data(
+			array(
+				'state' => array(
+					'core' => array(
+						'a' => 1,
+					),
+				),
+			)
+		);
+		WP_Directive_Store::merge_data(
+			array(
+				'state' => array(
+					'core' => array(
+						'b' => 2,
+					),
+				),
+			)
+		);
+		ob_start();
+		WP_Directive_Store::render();
+		$rendered = ob_get_clean();
+		$this->assertSame(
+			'<script id="store" type="application/json">{"state":{"core":{"a":1,"b":2}}}</script>',
+			$rendered,
+		);
+	}
+}

--- a/src/directives/attributes/wp-bind.php
+++ b/src/directives/attributes/wp-bind.php
@@ -15,7 +15,6 @@ function process_wp_bind( $tags, $context ) {
 			continue;
 		}
 
-		// TODO: Properly parse $value.
 		$expr  = $tags->get_attribute( $attr );
 		$value = evaluate( $expr, $context->get_context() );
 		$tags->set_attribute( $bound_attr, $value );

--- a/src/directives/attributes/wp-bind.php
+++ b/src/directives/attributes/wp-bind.php
@@ -17,7 +17,7 @@ function process_wp_bind( $tags, $context ) {
 
 		// TODO: Properly parse $value.
 		$expr  = $tags->get_attribute( $attr );
-		$value = get_from_context( $expr, $context->get_context() );
+		$value = evaluate( $expr, $context->get_context() );
 		$tags->set_attribute( $bound_attr, $value );
 	}
 }

--- a/src/directives/attributes/wp-class.php
+++ b/src/directives/attributes/wp-class.php
@@ -15,7 +15,6 @@ function process_wp_class( $tags, $context ) {
 			continue;
 		}
 
-		// TODO: Properly parse $value.
 		$expr      = $tags->get_attribute( $attr );
 		$add_class = evaluate( $expr, $context->get_context() );
 		if ( $add_class ) {

--- a/src/directives/attributes/wp-class.php
+++ b/src/directives/attributes/wp-class.php
@@ -17,7 +17,7 @@ function process_wp_class( $tags, $context ) {
 
 		// TODO: Properly parse $value.
 		$expr      = $tags->get_attribute( $attr );
-		$add_class = get_from_context( $expr, $context->get_context() );
+		$add_class = evaluate( $expr, $context->get_context() );
 		if ( $add_class ) {
 			$tags->add_class( $class_name );
 		} else {

--- a/src/directives/attributes/wp-style.php
+++ b/src/directives/attributes/wp-style.php
@@ -17,7 +17,7 @@ function process_wp_style( $tags, $context ) {
 
 		// TODO: Properly parse $value.
 		$expr        = $tags->get_attribute( $attr );
-		$style_value = get_from_context( $expr, $context->get_context() );
+		$style_value = evaluate( $expr, $context->get_context() );
 		if ( $style_value ) {
 			$style_attr = $tags->get_attribute( 'style' );
 			$style_attr = set_style( $style_attr, $style_name, $style_value );

--- a/src/directives/attributes/wp-style.php
+++ b/src/directives/attributes/wp-style.php
@@ -15,7 +15,6 @@ function process_wp_style( $tags, $context ) {
 			continue;
 		}
 
-		// TODO: Properly parse $value.
 		$expr        = $tags->get_attribute( $attr );
 		$style_value = evaluate( $expr, $context->get_context() );
 		if ( $style_value ) {

--- a/src/directives/class-wp-directive-store.php
+++ b/src/directives/class-wp-directive-store.php
@@ -8,11 +8,11 @@ class WP_Directive_Store {
 	}
 
 	static function merge_data( $data ) {
-		self::$store = array_merge_recursive( self::$store, $data );
+		self::$store = array_replace_recursive( self::$store, $data );
 	}
 
 	static function serialize() {
-		return json_enconde( self::$store );
+		return json_encode( self::$store );
 	}
 
 	static function reset() {

--- a/src/directives/class-wp-directive-store.php
+++ b/src/directives/class-wp-directive-store.php
@@ -8,7 +8,7 @@ class WP_Directive_Store {
 	}
 
 	static function merge_data( $data ) {
-		self::$store = array_merge_recursive( selfs::$store, $data );
+		self::$store = array_merge_recursive( self::$store, $data );
 	}
 
 	static function serialize() {

--- a/src/directives/class-wp-directive-store.php
+++ b/src/directives/class-wp-directive-store.php
@@ -10,4 +10,19 @@ class WP_Directive_Store {
 	static function merge_data( $data ) {
 		self::$store = array_merge_recursive( selfs::$store, $data );
 	}
+
+	static function serialize() {
+		return json_enconde( self::$store );
+	}
+
+	static function render() {
+		if ( empty( self::$store ) ) {
+			return;
+		}
+
+		// TODO: find a better ID for the script tag.
+		$id    = 'store';
+		$store = self::serialize();
+		echo "<script id=\"$id\" type=\"application/json\">$store</script>";
+	}
 }

--- a/src/directives/class-wp-directive-store.php
+++ b/src/directives/class-wp-directive-store.php
@@ -1,0 +1,13 @@
+<?php
+
+class WP_Directive_Store {
+	private static array $store = array();
+
+	static function get_data() {
+		return self::$store;
+	}
+
+	static function merge_data( $data ) {
+		self::$store = array_merge_recursive( selfs::$store, $data );
+	}
+}

--- a/src/directives/class-wp-directive-store.php
+++ b/src/directives/class-wp-directive-store.php
@@ -15,6 +15,10 @@ class WP_Directive_Store {
 		return json_enconde( self::$store );
 	}
 
+	static function reset() {
+		self::$store = array();
+	}
+
 	static function render() {
 		if ( empty( self::$store ) ) {
 			return;

--- a/src/directives/utils.php
+++ b/src/directives/utils.php
@@ -6,7 +6,7 @@ function store( $data ) {
 	WP_Directive_Store::merge_data( $data );
 }
 
-function evaluate( $path, $context ) {
+function evaluate( string $path, array $context = array() ) {
 	$current = array_merge(
 		WP_Directive_Store::get_data(),
 		array( 'context' => $context )

--- a/src/directives/utils.php
+++ b/src/directives/utils.php
@@ -6,6 +6,7 @@ function store( $data ) {
 	WP_Directive_Store::merge_data( $data );
 }
 
+// TODO: Implement evaluation of complex logical expressions.
 function evaluate( string $path, array $context = array() ) {
 	$current = array_merge(
 		WP_Directive_Store::get_data(),

--- a/src/directives/utils.php
+++ b/src/directives/utils.php
@@ -1,15 +1,26 @@
 <?php
 
-function get_from_context( $expr, $context ) {
-	$path = explode( '.', $expr );
-	if ( count( $path ) > 0 && 'context' === $path[0] ) {
-		array_shift( $path );
-		$result = $context;
-		foreach ( $path as $key ) {
-			$result = $result[ $key ];
+require_once  __DIR__ . '/class-wp-directive-store.php';
+
+function store( $data ) {
+	WP_Directive_Store::merge_data( $data );
+}
+
+function evaluate( $path, $context ) {
+	$current = array_merge(
+		WP_Directive_Store::get_data(),
+		array( 'context' => $context )
+	);
+
+	$array = explode( '.', $path );
+	foreach ( $array as $p ) {
+		if ( isset( $current[ $p ] ) ) {
+			$current = $current[ $p ];
+		} else {
+			return null;
 		}
 	}
-	return $result;
+	return $current;
 }
 
 function set_style( $style, $name, $value ) {

--- a/src/runtime/hooks.js
+++ b/src/runtime/hooks.js
@@ -1,6 +1,6 @@
 import { h, options, createContext } from 'preact';
 import { useRef } from 'preact/hooks';
-import { store } from './wpx';
+import { rawStore as store } from './store';
 import { componentPrefix } from './constants';
 
 // Main context.
@@ -18,7 +18,7 @@ export const component = (name, Comp) => {
 	componentMap[name] = Comp;
 };
 
-// Resolve the path to some property of the wpx object.
+// Resolve the path to some property of the store object.
 const resolve = (path, context) => {
 	let current = { ...store, context };
 	path.split('.').forEach((p) => (current = current[p]));

--- a/src/runtime/index.js
+++ b/src/runtime/index.js
@@ -1,6 +1,7 @@
 import registerDirectives from './directives';
 import registerComponents from './components';
 import { init } from './router';
+export { store } from './store';
 
 /**
  * Initialize the initial vDOM.

--- a/src/runtime/store.js
+++ b/src/runtime/store.js
@@ -16,7 +16,23 @@ export const deepMerge = (target, source) => {
 	}
 };
 
-const rawState = {};
+const getSerializedState = () => {
+	// TODO: change the store tag ID for a better one.
+	const storeTag = document.querySelector(
+		`script[type="application/json"]#store`
+	);
+	if (!storeTag) return {};
+	try {
+		const { state } = JSON.parse(storeTag.textContent);
+		if (isObject(state)) return state;
+		throw Error('Parsed state is not an object');
+	} catch (e) {
+		console.log(e);
+	}
+	return {};
+};
+
+const rawState = getSerializedState();
 export const rawStore = { state: deepSignal(rawState) };
 
 if (typeof window !== 'undefined') window.store = rawStore;

--- a/src/runtime/store.js
+++ b/src/runtime/store.js
@@ -17,11 +17,11 @@ export const deepMerge = (target, source) => {
 };
 
 const rawState = {};
-export const store = { state: deepSignal(rawState) };
+export const rawStore = { state: deepSignal(rawState) };
 
-if (typeof window !== 'undefined') window.wpx = store;
+if (typeof window !== 'undefined') window.store = rawStore;
 
-export const wpx = ({ state, ...block }) => {
-	deepMerge(store, block);
+export const store = ({ state, ...block }) => {
+	deepMerge(rawStore, block);
 	deepMerge(rawState, state);
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = [
 		...defaultConfig,
 		entry: {
 			runtime: './src/runtime',
-			'e2e/wpx': './e2e/wpx',
+			'e2e/store': './e2e/store',
 		},
 		output: {
 			filename: '[name].js',

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -258,4 +258,4 @@ add_filter(
 
 // TODO: check if priority 9 is enough.
 // TODO: check if `wp_footer` is the most appropriate hook.
-add_action( 'wp_footer', WP_Directive_Store::render, 9 );
+add_action( 'wp_footer', array( 'WP_Directive_Store', 'render' ), 9 );

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -35,7 +35,7 @@ if ( ! is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
 	return;
 }
 
-require_once __DIR__ . '/../gutenberg/lib/experimental/html/index.php';
+require_once __DIR__ . '/../gutenberg/lib/experimental/html/wp-html.php';
 
 require_once __DIR__ . '/src/directives/class-wp-directive-context.php';
 require_once __DIR__ . '/src/directives/class-wp-directive-store.php';

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -136,11 +136,13 @@ add_filter(
 	1
 );
 
-
 function wp_directives_get_client_side_transitions() {
 	static $client_side_transitions = null;
 	if ( is_null( $client_side_transitions ) ) {
-		$client_side_transitions = apply_filters( 'client_side_transitions', false );
+		$client_side_transitions = apply_filters(
+			'client_side_transitions',
+			false
+		);
 	}
 	return $client_side_transitions;
 }
@@ -162,12 +164,16 @@ add_filter(
 	9
 );
 
-function wp_directives_mark_interactive_blocks( $block_content, $block, $instance ) {
+function wp_directives_mark_interactive_blocks(
+	$block_content,
+	$block,
+	$instance
+) {
 	if ( wp_directives_get_client_side_transitions() ) {
 		return $block_content;
 	}
 
-		// Append the `wp-ignore` attribute for inner blocks of interactive blocks.
+	// Append the `wp-ignore` attribute for inner blocks of interactive blocks.
 	if ( isset( $instance->parsed_block['isolated'] ) ) {
 		$w = new WP_HTML_Tag_Processor( $block_content );
 		$w->next_tag();
@@ -175,17 +181,17 @@ function wp_directives_mark_interactive_blocks( $block_content, $block, $instanc
 		$block_content = (string) $w;
 	}
 
-		// Return if it's not interactive.
+	// Return if it's not interactive.
 	if ( ! block_has_support( $instance->block_type, array( 'interactivity' ) ) ) {
 		return $block_content;
 	}
 
-		// Add the `wp-island` attribute if it's interactive.
-		$w = new WP_HTML_Tag_Processor( $block_content );
-		$w->next_tag();
-		$w->set_attribute( 'wp-island', '' );
+	// Add the `wp-island` attribute if it's interactive.
+	$w = new WP_HTML_Tag_Processor( $block_content );
+	$w->next_tag();
+	$w->set_attribute( 'wp-island', '' );
 
-		return (string) $w;
+	return (string) $w;
 }
 add_filter( 'render_block', 'wp_directives_mark_interactive_blocks', 10, 3 );
 
@@ -197,7 +203,10 @@ function bhe_inner_blocks( $parsed_block, $source_block, $parent_block ) {
 		isset( $parent_block ) &&
 		block_has_support(
 			$parent_block->block_type,
-			array( 'interactivity', 'isolated' )
+			array(
+				'interactivity',
+				'isolated',
+			)
 		)
 	) {
 		$parsed_block['isolated'] = true;
@@ -221,7 +230,7 @@ function wp_process_directives( $block_content ) {
 
 	$tags = new WP_HTML_Tag_Processor( $block_content );
 
-	$context = new WP_Directive_Context;
+	$context = new WP_Directive_Context();
 	while ( $tags->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
 		$tag_name = strtolower( $tags->get_tag() );
 		if ( array_key_exists( $tag_name, $tag_directives ) ) {
@@ -235,11 +244,20 @@ function wp_process_directives( $block_content ) {
 					continue;
 				}
 
-				call_user_func( $attribute_directives[ $attribute ], $tags, $context );
+				call_user_func(
+					$attribute_directives[ $attribute ],
+					$tags,
+					$context
+				);
 			}
 		}
 	}
 
 	return $block_content;
 }
-add_filter( 'render_block', 'wp_process_directives', 10, 1 );
+add_filter(
+	'render_block',
+	'wp_process_directives',
+	10,
+	1
+);

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -38,6 +38,7 @@ if ( ! is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
 require_once __DIR__ . '/../gutenberg/lib/experimental/html/index.php';
 
 require_once __DIR__ . '/src/directives/class-wp-directive-context.php';
+require_once __DIR__ . '/src/directives/class-wp-directive-store.php';
 
 require_once __DIR__ . '/src/directives/attributes/wp-bind.php';
 require_once __DIR__ . '/src/directives/attributes/wp-class.php';
@@ -261,3 +262,7 @@ add_filter(
 	10,
 	1
 );
+
+// TODO: check if priority 9 is enough.
+// TODO: check if `wp_footer` is the most appropriate hook.
+add_action( 'wp_footer', WP_Directive_Store::render, 9 );


### PR DESCRIPTION
## What

Adds store serialization and hydration.

## Why

The framework requires them. Developers should be able to send the initial state from the server as part of the SSR.

## How

- [x] Implementing a `WP_Directive_Store` class that contains the generated state.
- [x] Adding a `store( $data )` function to define the state on the block's render callback.
- [x] Adding a `evaluate( $path, $context )` function to access both the state and the context (like in JS)
- [x] Serializing and sending the store's content to the client in a `<script type="application/json">` tag.
- [x] Parsing the serialized store in the client and using it to initialize the store.
- [x] Rename `wpx` to `store`