### PR TITLE
Handle missing class attribute inside `wp-class`

### DIFF
--- a/e2e/directives-class.html
+++ b/e2e/directives-class.html
@@ -52,6 +52,11 @@
 			data-testid="can toggle class in the middle"
 		></div>
 
+		<div
+			wp-class:foo="state.falseValue"
+			data-testid="can toggle class when class attribute is missing"
+		></div>
+
 		<wp-context data='{ "falseValue": false }'>
 			<div
 				class="foo"

--- a/e2e/directives-class.spec.ts
+++ b/e2e/directives-class.spec.ts
@@ -63,6 +63,19 @@ test.describe('wp-class', () => {
 		await expect(el).toHaveClass('foo bar baz');
 	});
 
+	test('can toggle class when class attribute is missing', async ({
+		page,
+	}) => {
+		const el = page.getByTestId(
+			'can toggle class when class attribute is missing'
+		);
+		await expect(el).toHaveClass('');
+		page.getByTestId('toggle falseValue').click();
+		await expect(el).toHaveClass('foo');
+		page.getByTestId('toggle falseValue').click();
+		await expect(el).toHaveClass('');
+	});
+
 	test('can use context values', async ({ page }) => {
 		const el = page.getByTestId('can use context values');
 		await expect(el).toHaveClass('');

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -80,19 +80,19 @@ export default () => {
 						className: name,
 						context: contextValue,
 					});
+					const currentClass = element.props.class || '';
+					const classFinder = new RegExp(
+						`(^|\\s)${name}(\\s|$)`,
+						'g'
+					);
 					if (!result)
-						element.props.class = element.props.class
-							.replace(
-								new RegExp(`(^|\\s)${name}(\\s|$)`, 'g'),
-								' '
-							)
+						element.props.class = currentClass
+							.replace(classFinder, ' ')
 							.trim();
-					else if (
-						!new RegExp(`(^|\\s)${name}(\\s|$)`).test(
-							element.props.class
-						)
-					)
-						element.props.class += ` ${name}`;
+					else if (!classFinder.test(currentClass))
+						element.props.class = currentClass
+							? `${currentClass} ${name}`
+							: name;
 
 					useEffect(() => {
 						// This seems necessary because Preact doesn't change the class names


### PR DESCRIPTION
## What

Fixes a bug while hydrating `wp-class` directives. It happens when the `class` attribute is not defined―something that occurs when no class is server-side rendered. E.g., the following HTML

```html
<div wp-class:foo="state.falseValue"></div>
<button wp-on:click="actions.toggleFalseValue">Toggle</button>
```

currently throws this error:

<img width="818" alt="Screenshot 2023-02-14 at 18 51 25" src="https://user-images.githubusercontent.com/6917969/218817927-c25d7807-2150-4f45-92cf-3c6deb5ef689.png">

Also, when the button is clicked, the application crashes.

## Why

Directives should take care of those attributes they affect.

In this case, developers shouldn't be forced to write an empty class to make the `wp-class` directive work as expected.

## How

Simply using an empty string when `element.props.class` is undefined.