### PR TITLE
Fix `wp_process_directives` output

### DIFF
--- a/wp-directives.php
+++ b/wp-directives.php
@@ -216,7 +216,7 @@ function wp_process_directives( $block_content ) {
 	);
 
 	$attribute_directives = array(
-		// 'wp-context' => 'process_wp_context_attribute', // TODO
+		'wp-context' => 'process_wp_context_attribute',
 		'wp-bind'  => 'process_wp_bind',
 		'wp-class' => 'process_wp_class',
 		'wp-style' => 'process_wp_style',
@@ -234,12 +234,13 @@ function wp_process_directives( $block_content ) {
 			$attributes = $tags->get_attribute_names_with_prefix( 'wp-' );
 
 			foreach ( $attributes as $attribute ) {
-				if ( ! array_key_exists( $attribute, $attribute_directives ) ) {
+				list( $type ) = explode( ':', $attribute );
+				if ( ! array_key_exists( $type, $attribute_directives ) ) {
 					continue;
 				}
 
 				call_user_func(
-					$attribute_directives[ $attribute ],
+					$attribute_directives[ $type ],
 					$tags,
 					$context
 				);
@@ -247,7 +248,7 @@ function wp_process_directives( $block_content ) {
 		}
 	}
 
-	return $block_content;
+	return $tags->get_updated_html();
 }
 add_filter(
 	'render_block',


### PR DESCRIPTION
## What

Fixes a couple of bugs while processing directives and generating the new HTML.

## Why

The HTML output is basically `$block_content`, unchanged. 😅 

## How

1. Returning the updated HTML from the `WP_HTML_Tag_Processor`.
2. Getting the directive type from the attribute (`type:name`) before looking for the directive function.
3. Using the already implemented `wp-context` attribute.


I guess we'll have to implement tests for `wp_process_directives` sooner than later. ☝️ 