### PR TITLE
Process directive attributes with a colon (e.g. `wp-bind:value`)

### DIFF
--- a/phpunit/directives/wp-process-directives.php
+++ b/phpunit/directives/wp-process-directives.php
@@ -47,4 +47,18 @@ class Tests_Directives_WpProcessDirectives extends WP_UnitTestCase {
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		wp_process_directives( $tags, 'foo-', array(), $attribute_directives );
 	}
+
+	public function test_directives_with_type_and_name_are_processed_correctly() {
+		$test_helper = $this->createMock( Helper_Class::class );
+		$test_helper->expects( $this->atLeastOnce() )
+					->method( 'process_foo_test' );
+
+		$attribute_directives = array(
+			'foo-test' => array( $test_helper, 'process_foo_test' ),
+		);
+
+		$markup = '<div foo-test:value="abc"></div>';
+		$tags   = new WP_HTML_Tag_Processor( $markup );
+		wp_process_directives( $tags, 'foo-', array(), $attribute_directives );
+	}
 }

--- a/phpunit/directives/wp-process-directives.php
+++ b/phpunit/directives/wp-process-directives.php
@@ -48,7 +48,7 @@ class Tests_Directives_WpProcessDirectives extends WP_UnitTestCase {
 		wp_process_directives( $tags, 'foo-', array(), $attribute_directives );
 	}
 
-	public function test_directives_with_type_and_name_are_processed_correctly() {
+	public function test_directives_with_colon_processed_correctly() {
 		$test_helper = $this->createMock( Helper_Class::class );
 		$test_helper->expects( $this->atLeastOnce() )
 					->method( 'process_foo_test' );

--- a/src/directives/wp-process-directives.php
+++ b/src/directives/wp-process-directives.php
@@ -30,6 +30,8 @@ function wp_process_directives( $tags, $prefix, $tag_directives, $attribute_dire
 					}
 				}
 			} else {
+				// Helper that removes the part after the colon before looking
+				// for the directive processor inside `$attribute_directives`.
 				$get_directive_type = function ( $attr ) {
 					return strtok( $attr, ':' );
 				};

--- a/src/directives/wp-process-directives.php
+++ b/src/directives/wp-process-directives.php
@@ -30,7 +30,12 @@ function wp_process_directives( $tags, $prefix, $tag_directives, $attribute_dire
 					}
 				}
 			} else {
+				$get_directive_type = function ( $attr ) {
+					return strtok( $attr, ':' );
+				};
+
 				$attributes = $tags->get_attribute_names_with_prefix( $prefix );
+				$attributes = array_map( $get_directive_type, $attributes );
 				$attributes = array_intersect( $attributes, array_keys( $attribute_directives ) );
 
 				// If this is an open tag, and if it either has attribute directives,


### PR DESCRIPTION
## What

The title is self-explanatory. 🙂 

## Why

Right now, directives using a colon are not processed and thus ignored because they're not found inside `$attribute_directives`:

https://github.com/WordPress/block-hydration-experiments/blob/b3df431c3436bb5f41fede36b9307cd5d770dd67/wp-directives.php#L219-L224

## How

Simply filtering the colon and the part that follows from attributes before doing the search.