### PR TITLE
Add `wp-show` directive attribute

### DIFF
--- a/e2e/directives-show.html
+++ b/e2e/directives-show.html
@@ -34,7 +34,20 @@
 			<p>falseValue children</p>
 		</div>
 
-		<div>Add block with context</div>
+		<div wp-context='{ "falseValue": false }'>
+			<div
+				wp-show="context.falseValue"
+				data-testid="can use context values"
+			>
+				falseValue
+			</div>
+			<button
+				wp-on:click="actions.toggleContextFalseValue"
+				data-testid="toggle context false value"
+			>
+				Toggle context falseValue
+			</button>
+		</div>
 
 		<script src="../build/e2e/store.js"></script>
 		<script src="../build/runtime.js"></script>

--- a/e2e/directives-show.html
+++ b/e2e/directives-show.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Directives -- wp-show</title>
+		<meta itemprop="wp-client-side-navigation" content="active" />
+	</head>
+	<body>
+		<button
+			wp-on:click="actions.toggleTrueValue"
+			data-testid="toggle trueValue"
+		>
+			Toggle trueValue
+		</button>
+
+		<button
+			wp-on:click="actions.toggleFalseValue"
+			data-testid="toggle falseValue"
+		>
+			Toggle falseValue
+		</button>
+
+		<div
+			wp-show="state.trueValue"
+			id="truthy-div"
+			data-testid="show if callback returns truthy value"
+		>
+			<p>trueValue children</p>
+		</div>
+
+		<div
+			wp-show="state.falseValue"
+			data-testid="do not show if callback returns false value"
+		>
+			<p>falseValue children</p>
+		</div>
+
+		<div>Add block with context</div>
+
+		<script src="../build/e2e/store.js"></script>
+		<script src="../build/runtime.js"></script>
+		<script src="../build/vendors.js"></script>
+	</body>
+</html>

--- a/e2e/directives-show.spec.ts
+++ b/e2e/directives-show.spec.ts
@@ -6,10 +6,41 @@ test.describe('wp-show', () => {
 		await page.goto('file://' + join(__dirname, 'directives-show.html'));
 	});
 
+	test('show if callback returns truthy value', async ({ page }) => {
+		await page.pause();
+		const el = page.getByTestId('show if callback returns truthy value');
+		await expect(el).toBeVisible();
+	});
+
 	test('do not show if callback returns falsy value', async ({ page }) => {
-		const el1 = page.getByTestId('show if callback returns truthy value');
-		await expect(el1).toBeVisible();
-		const el2 = page.getByTestId('do not show if callback returns false value')
-		await expect(el2).toBeHidden();
+		const el = page.getByTestId('do not show if callback returns false value')
+		await expect(el).toBeHidden();
+	});
+
+	test('hide when toggling truthy value to falsy', async ({ page }) => {
+		const el = page.getByTestId('show if callback returns truthy value');
+		await expect(el).toBeVisible();
+		page.getByTestId('toggle trueValue').click();
+		await expect(el).toBeHidden();
+		page.getByTestId('toggle trueValue').click();
+		await expect(el).toBeVisible();
+	});
+
+	test('show when toggling false value to truthy', async ({ page }) => {
+		const el = page.getByTestId('do not show if callback returns false value');
+		await expect(el).toBeHidden();
+		page.getByTestId('toggle falseValue').click();
+		await expect(el).toBeVisible();
+		page.getByTestId('toggle falseValue').click();
+		await expect(el).toBeHidden();
+	});
+
+	test('can use context values', async ({ page }) => {
+		const el = page.getByTestId('can use context values');
+		await expect(el).toBeHidden();
+		page.getByTestId('toggle context false value').click();
+		await expect(el).toBeVisible();
+		page.getByTestId('toggle context false value').click();
+		await expect(el).toBeHidden();
 	});
 });

--- a/e2e/directives-show.spec.ts
+++ b/e2e/directives-show.spec.ts
@@ -1,0 +1,15 @@
+import { join } from 'path';
+import { test, expect } from '@playwright/test';
+
+test.describe('wp-show', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('file://' + join(__dirname, 'directives-show.html'));
+	});
+
+	test('do not show if callback returns falsy value', async ({ page }) => {
+		const el1 = page.getByTestId('show if callback returns truthy value');
+		await expect(el1).toBeVisible();
+		const el2 = page.getByTestId('do not show if callback returns false value')
+		await expect(el2).toBeHidden();
+	});
+});

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -162,4 +162,24 @@ export default () => {
 			}
 		}
 	);
+
+	// wp-show
+	directive(
+		'show',
+		({
+			directives: {
+				show: { default: show },
+			},
+			props: { children },
+			evaluate,
+			context,
+		}) => {
+			const contextValue = useContext(context);
+			if (evaluate(show, { context: contextValue })) {
+				return children;
+			} else {
+				return <template>{children}</template>;
+			}
+		}
+	);
 };

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -170,16 +170,15 @@ export default () => {
 			directives: {
 				show: { default: show },
 			},
-			props: { children },
+			element,
 			evaluate,
 			context,
 		}) => {
 			const contextValue = useContext(context);
-			if (evaluate(show, { context: contextValue })) {
-				return children;
-			} else {
-				return <template>{children}</template>;
-			}
+			if (!evaluate(show, { context: contextValue }))
+				element.props.children = (
+					<template>{element.props.children}</template>
+				);
 		}
 	);
 };


### PR DESCRIPTION
This pull request aims to replicate the behavior of the [`wp-show` directive tag (component)](https://github.com/WordPress/block-hydration-experiments/blob/main-wp-directives-plugin/src/runtime/components.js#L13-L22), but using a directive attribute instead.

It's true that in terms of functionality, the directive tag should be enough for now, but both approaches should be available. Especially if we end up [removing directive tags (components) from the proposal](https://github.com/WordPress/block-hydration-experiments/issues/152).

In [the movies demo](https://github.com/c4rl0sbr4v0/wp-movies-demo/), we will use this directive, so it would be great if we could just use directive tags.