### PR TITLE
Remove HTML Tag Processor Gutenberg requirement

### DIFF
--- a/wp-directives.php
+++ b/wp-directives.php
@@ -35,8 +35,6 @@ if ( ! is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
 	return;
 }
 
-require_once __DIR__ . '/../gutenberg/lib/experimental/html/wp-html.php';
-
 require_once __DIR__ . '/src/directives/class-wp-directive-context.php';
 require_once __DIR__ . '/src/directives/class-wp-directive-store.php';
 require_once __DIR__ . '/src/directives/wp-process-directives.php';


### PR DESCRIPTION
If I am not mistaken, now that the Tag Processor is included in WordPress 6.2, we should remove the following dependency:

```php
require_once __DIR__ . '/../gutenberg/lib/experimental/html/wp-html.php';
```

After this Pull Request: [HTML API: Move into 6.2 Compat Folder since inclusion in Core](https://github.com/WordPress/gutenberg/pull/47749), that file doesn't exist anymore, and it seems to be causing issues. At least it's causing them locally to me.

Not 100% sure if this is the correct fix, you may know better than me @ockham .