### PR TITLE
Fix `WP_HTML_Tag_Processor` imports

### DIFF
--- a/phpunit/directives/attributes/wp-bind.php
+++ b/phpunit/directives/attributes/wp-bind.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../src/directives/attributes/wp-bind.php';
 
 require_once __DIR__ . '/../../../src/directives/class-wp-directive-context.php';
 
-require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/wp-html.php';
+require_once __DIR__ . '/../../../src/directives/wp-html.php';
 
 /**
  * Tests for the wp-bind directive.

--- a/phpunit/directives/attributes/wp-class.php
+++ b/phpunit/directives/attributes/wp-class.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../src/directives/attributes/wp-class.php';
 
 require_once __DIR__ . '/../../../src/directives/class-wp-directive-context.php';
 
-require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/wp-html.php';
+require_once __DIR__ . '/../../../src/directives/wp-html.php';
 
 /**
  * Tests for the wp-class directive.

--- a/phpunit/directives/attributes/wp-context.php
+++ b/phpunit/directives/attributes/wp-context.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../src/directives/attributes/wp-context.php';
 
 require_once __DIR__ . '/../../../src/directives/class-wp-directive-context.php';
 
-require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/wp-html.php';
+require_once __DIR__ . '/../../../src/directives/wp-html.php';
 
 /**
  * Tests for the wp-context attribute directive.

--- a/phpunit/directives/attributes/wp-style.php
+++ b/phpunit/directives/attributes/wp-style.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../src/directives/attributes/wp-style.php';
 
 require_once __DIR__ . '/../../../src/directives/class-wp-directive-context.php';
 
-require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/wp-html.php';
+require_once __DIR__ . '/../../../src/directives/wp-html.php';
 
 /**
  * Tests for the wp-style directive.

--- a/phpunit/directives/tags/wp-context.php
+++ b/phpunit/directives/tags/wp-context.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../src/directives/tags/wp-context.php';
 
 require_once __DIR__ . '/../../../src/directives/class-wp-directive-context.php';
 
-require_once __DIR__ . '/../../../../gutenberg/lib/experimental/html/wp-html.php';
+require_once __DIR__ . '/../../../src/directives/wp-html.php';
 
 /**
  * Tests for the wp-context tag directive.

--- a/phpunit/directives/wp-process-directives.php
+++ b/phpunit/directives/wp-process-directives.php
@@ -5,7 +5,7 @@
 
 require_once __DIR__ . '/../../src/directives/wp-process-directives.php';
 
-require_once __DIR__ . '/../../../gutenberg/lib/experimental/html/wp-html.php';
+require_once __DIR__ . '/../../src/directives/wp-html.php';
 
 class Helper_Class {
 	function process_foo_test( $tags, $context ) {

--- a/src/directives/wp-html.php
+++ b/src/directives/wp-html.php
@@ -1,0 +1,8 @@
+<?php
+
+if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
+	require __DIR__ . '/../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-attribute-token.php';
+	require __DIR__ . '/../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-span.php';
+	require __DIR__ . '/../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-text-replacement.php';
+	require __DIR__ . '/../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-tag-processor.php';
+}

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -35,7 +35,7 @@ if ( ! is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
 	return;
 }
 
-require_once __DIR__ . '/../gutenberg/lib/experimental/html/wp-html.php';
+require_once __DIR__ . '/src/directives/wp-html.php';
 
 require_once __DIR__ . '/src/directives/class-wp-directive-context.php';
 require_once __DIR__ . '/src/directives/class-wp-directive-store.php';


### PR DESCRIPTION
During preparation for the WP 6.2 release, the HTML Tag Processor files inside the Gutenberg plugin were [moved](https://github.com/WordPress/gutenberg/pull/47749) from `lib/experimental/html/` to `lib/compat/wordpress-6.2/html-api/`.

This PR updates the import locations accordingly, and sort of "centralizes" them, so we only reference the external dependency in one file (and can potentially later to point to e.g. `lib/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-processor-6-3.php`, which has some features added after the WP 6.2 Feature Freeze, if needed).

See #161 for more context.