### PR TITLE
Add client-side navigation support for `wp-ignore` directive

### DIFF
--- a/e2e/tovdom-full-next.html
+++ b/e2e/tovdom-full-next.html
@@ -1,18 +1,13 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>toVdom - full</title>
+		<title>toVdom - full (next)</title>
 		<meta itemprop="wp-client-side-navigation" content="active" />
 	</head>
 	<body>
 		<div wp-ignore>
-			<wp-show when="state.falseValue">
-				<span data-testid="inside wp-ignore">
-					This should not be shown because we are in full mode.
-				</span>
-			</wp-show>
+			<!-- nothing here, content erased -->
 		</div>
-		<a href="./tovdom-full-next.html" wp-link>next</a>
 
 		<script src="../build/e2e/store.js"></script>
 		<script src="../build/runtime.js"></script>

--- a/e2e/tovdom-full-next.html
+++ b/e2e/tovdom-full-next.html
@@ -6,7 +6,9 @@
 	</head>
 	<body>
 		<div wp-ignore>
-			<!-- nothing here, content erased -->
+			<span data-testid="new content inside wp-ignore">
+				New content.
+			</span>
 		</div>
 
 		<script src="../build/e2e/store.js"></script>

--- a/e2e/tovdom-full.html
+++ b/e2e/tovdom-full.html
@@ -12,7 +12,7 @@
 				</span>
 			</wp-show>
 		</div>
-		<a href="./tovdom-full-next.html" wp-link>next</a>
+		<a href="./tovdom-full-next.html" wp-link data-testid="next">next</a>
 
 		<script src="../build/e2e/store.js"></script>
 		<script src="../build/runtime.js"></script>

--- a/e2e/tovdom-full.spec.ts
+++ b/e2e/tovdom-full.spec.ts
@@ -3,10 +3,26 @@ import { test, expect } from '@playwright/test';
 
 test.describe('toVdom - full', () => {
 	test.beforeEach(async ({ page }) => {
-		await page.goto('file://' + join(__dirname, 'tovdom-full.html'));
+		await page.route('**/*.html', async (route, req) => {
+			const { pathname } = new URL(req.url());
+			route.fulfill({ path: join(__dirname, pathname) });
+		});
+
+		await page.goto('http://a.b/tovdom-full.html');
 	});
 
 	test('it should stop when it founds wp-ignore', async ({ page }) => {
+		const el = page.getByTestId('inside wp-ignore');
+		await expect(el).toBeVisible();
+	});
+
+	test('it should not change wp-ignore content after navigation', async ({
+		page,
+	}) => {
+		// Next HTML purposely removes all content inside `wp-ignore`.
+		await page.getByRole('link').click();
+
+		// HTML content inside `wp-ignore` should remain.
 		const el = page.getByTestId('inside wp-ignore');
 		await expect(el).toBeVisible();
 	});

--- a/e2e/tovdom-full.spec.ts
+++ b/e2e/tovdom-full.spec.ts
@@ -3,9 +3,15 @@ import { test, expect } from '@playwright/test';
 
 test.describe('toVdom - full', () => {
 	test.beforeEach(async ({ page }) => {
+		// Helpers to use URLs with http:// instead of file:// to avoid errors
+		// inside `fetch` calls.
 		await page.route('**/*.html', async (route, req) => {
 			const { pathname } = new URL(req.url());
 			route.fulfill({ path: join(__dirname, pathname) });
+		});
+		await page.route('**/*.js', async (route, req) => {
+			const { pathname } = new URL(req.url());
+			route.fulfill({ path: join(__dirname, '..', pathname) });
 		});
 
 		await page.goto('http://a.b/tovdom-full.html');
@@ -19,11 +25,16 @@ test.describe('toVdom - full', () => {
 	test('it should not change wp-ignore content after navigation', async ({
 		page,
 	}) => {
-		// Next HTML purposely removes all content inside `wp-ignore`.
-		await page.getByRole('link').click();
+		// Next HTML purposely changes content inside `wp-ignore`.
+		await page.getByTestId('next').click();
 
-		// HTML content inside `wp-ignore` should remain.
-		const el = page.getByTestId('inside wp-ignore');
-		await expect(el).toBeVisible();
+		const oldContent = page.getByTestId('inside wp-ignore');
+		await expect(oldContent).toBeVisible();
+
+		const newContent = page.getByTestId('new content inside wp-ignore');
+		await expect(newContent).not.toBeVisible();
+
+		const link = page.getByTestId('next');
+		await expect(link).not.toBeVisible();
 	});
 });

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -181,4 +181,21 @@ export default () => {
 				);
 		}
 	);
+
+	// wp-ignore
+	directive(
+		'ignore',
+		({
+			element: {
+				type: Type,
+				props: { innerHTML, ...rest },
+			},
+		}) => {
+			// Preserve the initial inner HTML.
+			const cached = useMemo(() => innerHTML, []);
+			return (
+				<Type dangerouslySetInnerHTML={{ __html: cached }} {...rest} />
+			);
+		}
+	);
 };

--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -48,7 +48,9 @@ export function toVdom(node) {
 
 	if (ignore && !island)
 		return h(node.localName, {
-			dangerouslySetInnerHTML: { __html: node.innerHTML },
+			...props,
+			innerHTML: node.innerHTML,
+			directives: { ignore: true },
 		});
 	if (island) hydratedIslands.add(node);
 


### PR DESCRIPTION
## What

Allows elements with the `wp-ignore` directive to keep their content after `navigate` calls.

## Why

During navigations, the content inside elements with `wp-ignore` could change, and those updates should not be reflected (those parts of the HTML document should be ignored).

## How

Implementing the `ignore` directive in a way that:
1. its content it's not parsed.
2. the value for the `dangerouslySetInnerHTML` prop never changes.