### PR TITLE
SSR: Add `wp-html` and `wp-text` attribute directive processors

### DIFF
--- a/phpunit/directives/attributes/wp-html.php
+++ b/phpunit/directives/attributes/wp-html.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * wp-html tag directive test.
+ */
+
+require_once __DIR__ . '/../../../src/directives/attributes/wp-html.php';
+
+require_once __DIR__ . '/../../../src/directives/class-wp-directive-context.php';
+require_once __DIR__ . '/../../../src/directives/class-wp-directive-processor.php';
+
+require_once __DIR__ . '/../../../src/directives/wp-html.php';
+
+/**
+ * Tests for the wp-html tag directive.
+ *
+ * @group  directives
+ * @covers process_wp_html
+ */
+class Tests_Directives_WpHtml extends WP_UnitTestCase {
+	public function test_directive_sets_inner_html_based_on_attribute_value_and_retains_html() {
+		$markup = '<div wp-html="context.myblock.someHtml"></div>';
+
+		$tags = new WP_Directive_Processor( $markup );
+		$tags->next_tag();
+
+		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'someHtml' => 'Lorem <em>ipsum</em> dolor sit.' ) ) );
+		$context        = clone $context_before;
+		process_wp_html( $tags, $context );
+
+		$expected_markup = '<div wp-html="context.myblock.someHtml">Lorem <em>ipsum</em> dolor sit.</div>';
+		$this->assertSame( $expected_markup, $tags->get_updated_html() );
+		$this->assertSame( $context_before->get_context(), $context->get_context(), 'wp-html directive changed context' );
+	}
+
+	public function test_directive_overwrites_inner_html_based_on_attribute_value() {
+		$markup = '<div wp-html="context.myblock.someHtml">Lorem ipsum dolor sit.</div>';
+
+		$tags = new WP_Directive_Processor( $markup );
+		$tags->next_tag();
+
+		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'someHtml' => 'Honi soit qui mal y pense.' ) ) );
+		$context        = clone $context_before;
+		process_wp_html( $tags, $context );
+
+		$expected_markup = '<div wp-html="context.myblock.someHtml">Honi soit qui mal y pense.</div>';
+		$this->assertSame( $expected_markup, $tags->get_updated_html() );
+		$this->assertSame( $context_before->get_context(), $context->get_context(), 'wp-html directive changed context' );
+	}
+}

--- a/phpunit/directives/attributes/wp-html.php
+++ b/phpunit/directives/attributes/wp-html.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * wp-html tag directive test.
+ * data-wp-html tag directive test.
  */
 
 require_once __DIR__ . '/../../../src/directives/attributes/wp-html.php';
@@ -11,14 +11,14 @@ require_once __DIR__ . '/../../../src/directives/class-wp-directive-processor.ph
 require_once __DIR__ . '/../../../src/directives/wp-html.php';
 
 /**
- * Tests for the wp-html tag directive.
+ * Tests for the data-wp-html tag directive.
  *
  * @group  directives
  * @covers process_wp_html
  */
 class Tests_Directives_WpHtml extends WP_UnitTestCase {
 	public function test_directive_sets_inner_html_based_on_attribute_value_and_retains_html() {
-		$markup = '<div wp-html="context.myblock.someHtml"></div>';
+		$markup = '<div data-wp-html="context.myblock.someHtml"></div>';
 
 		$tags = new WP_Directive_Processor( $markup );
 		$tags->next_tag();
@@ -27,13 +27,13 @@ class Tests_Directives_WpHtml extends WP_UnitTestCase {
 		$context        = clone $context_before;
 		process_wp_html( $tags, $context );
 
-		$expected_markup = '<div wp-html="context.myblock.someHtml">Lorem <em>ipsum</em> dolor sit.</div>';
+		$expected_markup = '<div data-wp-html="context.myblock.someHtml">Lorem <em>ipsum</em> dolor sit.</div>';
 		$this->assertSame( $expected_markup, $tags->get_updated_html() );
-		$this->assertSame( $context_before->get_context(), $context->get_context(), 'wp-html directive changed context' );
+		$this->assertSame( $context_before->get_context(), $context->get_context(), 'data-wp-html directive changed context' );
 	}
 
 	public function test_directive_overwrites_inner_html_based_on_attribute_value() {
-		$markup = '<div wp-html="context.myblock.someHtml">Lorem ipsum dolor sit.</div>';
+		$markup = '<div data-wp-html="context.myblock.someHtml">Lorem ipsum dolor sit.</div>';
 
 		$tags = new WP_Directive_Processor( $markup );
 		$tags->next_tag();
@@ -42,8 +42,8 @@ class Tests_Directives_WpHtml extends WP_UnitTestCase {
 		$context        = clone $context_before;
 		process_wp_html( $tags, $context );
 
-		$expected_markup = '<div wp-html="context.myblock.someHtml">Honi soit qui mal y pense.</div>';
+		$expected_markup = '<div data-wp-html="context.myblock.someHtml">Honi soit qui mal y pense.</div>';
 		$this->assertSame( $expected_markup, $tags->get_updated_html() );
-		$this->assertSame( $context_before->get_context(), $context->get_context(), 'wp-html directive changed context' );
+		$this->assertSame( $context_before->get_context(), $context->get_context(), 'data-wp-html directive changed context' );
 	}
 }

--- a/phpunit/directives/attributes/wp-text.php
+++ b/phpunit/directives/attributes/wp-text.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * wp-text tag directive test.
+ */
+
+require_once __DIR__ . '/../../../src/directives/attributes/wp-text.php';
+
+require_once __DIR__ . '/../../../src/directives/class-wp-directive-context.php';
+require_once __DIR__ . '/../../../src/directives/class-wp-directive-processor.php';
+
+require_once __DIR__ . '/../../../src/directives/wp-html.php';
+
+/**
+ * Tests for the wp-text tag directive.
+ *
+ * @group  directives
+ * @covers process_wp_text
+ */
+class Tests_Directives_WpText extends WP_UnitTestCase {
+	public function test_directive_sets_inner_html_based_on_attribute_value() {
+		$markup = '<div wp-text="context.myblock.someText"></div>';
+
+		$tags = new WP_Directive_Processor( $markup );
+		$tags->next_tag();
+
+		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'someText' => 'Lorem ipsum dolor sit.' ) ) );
+		$context        = clone $context_before;
+		process_wp_text( $tags, $context );
+
+		$expected_markup = '<div wp-text="context.myblock.someText">Lorem ipsum dolor sit.</div>';
+		$this->assertSame( $expected_markup, $tags->get_updated_html() );
+		$this->assertSame( $context_before->get_context(), $context->get_context(), 'wp-text directive changed context' );
+	}
+
+	public function test_directive_overwrites_inner_html_based_on_attribute_value() {
+		$markup = '<div wp-text="context.myblock.someText">Lorem ipsum dolor sit.</div>';
+
+		$tags = new WP_Directive_Processor( $markup );
+		$tags->next_tag();
+
+		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'someText' => 'Honi soit qui mal y pense.' ) ) );
+		$context        = clone $context_before;
+		process_wp_text( $tags, $context );
+
+		$expected_markup = '<div wp-text="context.myblock.someText">Honi soit qui mal y pense.</div>';
+		$this->assertSame( $expected_markup, $tags->get_updated_html() );
+		$this->assertSame( $context_before->get_context(), $context->get_context(), 'wp-text directive changed context' );
+	}
+}

--- a/phpunit/directives/attributes/wp-text.php
+++ b/phpunit/directives/attributes/wp-text.php
@@ -17,17 +17,17 @@ require_once __DIR__ . '/../../../src/directives/wp-html.php';
  * @covers process_wp_text
  */
 class Tests_Directives_WpText extends WP_UnitTestCase {
-	public function test_directive_sets_inner_html_based_on_attribute_value() {
+	public function test_directive_sets_inner_html_based_on_attribute_value_and_escapes_html() {
 		$markup = '<div wp-text="context.myblock.someText"></div>';
 
 		$tags = new WP_Directive_Processor( $markup );
 		$tags->next_tag();
 
-		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'someText' => 'Lorem ipsum dolor sit.' ) ) );
+		$context_before = new WP_Directive_Context( array( 'myblock' => array( 'someText' => 'The HTML tag <br> produces a line break.' ) ) );
 		$context        = clone $context_before;
 		process_wp_text( $tags, $context );
 
-		$expected_markup = '<div wp-text="context.myblock.someText">Lorem ipsum dolor sit.</div>';
+		$expected_markup = '<div wp-text="context.myblock.someText">The HTML tag &lt;br&gt; produces a line break.</div>';
 		$this->assertSame( $expected_markup, $tags->get_updated_html() );
 		$this->assertSame( $context_before->get_context(), $context->get_context(), 'wp-text directive changed context' );
 	}

--- a/phpunit/directives/attributes/wp-text.php
+++ b/phpunit/directives/attributes/wp-text.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * wp-text tag directive test.
+ * data-wp-text tag directive test.
  */
 
 require_once __DIR__ . '/../../../src/directives/attributes/wp-text.php';
@@ -11,14 +11,14 @@ require_once __DIR__ . '/../../../src/directives/class-wp-directive-processor.ph
 require_once __DIR__ . '/../../../src/directives/wp-html.php';
 
 /**
- * Tests for the wp-text tag directive.
+ * Tests for the data-wp-text tag directive.
  *
  * @group  directives
  * @covers process_wp_text
  */
 class Tests_Directives_WpText extends WP_UnitTestCase {
 	public function test_directive_sets_inner_html_based_on_attribute_value_and_escapes_html() {
-		$markup = '<div wp-text="context.myblock.someText"></div>';
+		$markup = '<div data-wp-text="context.myblock.someText"></div>';
 
 		$tags = new WP_Directive_Processor( $markup );
 		$tags->next_tag();
@@ -27,13 +27,13 @@ class Tests_Directives_WpText extends WP_UnitTestCase {
 		$context        = clone $context_before;
 		process_wp_text( $tags, $context );
 
-		$expected_markup = '<div wp-text="context.myblock.someText">The HTML tag &lt;br&gt; produces a line break.</div>';
+		$expected_markup = '<div data-wp-text="context.myblock.someText">The HTML tag &lt;br&gt; produces a line break.</div>';
 		$this->assertSame( $expected_markup, $tags->get_updated_html() );
-		$this->assertSame( $context_before->get_context(), $context->get_context(), 'wp-text directive changed context' );
+		$this->assertSame( $context_before->get_context(), $context->get_context(), 'data-wp-text directive changed context' );
 	}
 
 	public function test_directive_overwrites_inner_html_based_on_attribute_value() {
-		$markup = '<div wp-text="context.myblock.someText">Lorem ipsum dolor sit.</div>';
+		$markup = '<div data-wp-text="context.myblock.someText">Lorem ipsum dolor sit.</div>';
 
 		$tags = new WP_Directive_Processor( $markup );
 		$tags->next_tag();
@@ -42,8 +42,8 @@ class Tests_Directives_WpText extends WP_UnitTestCase {
 		$context        = clone $context_before;
 		process_wp_text( $tags, $context );
 
-		$expected_markup = '<div wp-text="context.myblock.someText">Honi soit qui mal y pense.</div>';
+		$expected_markup = '<div data-wp-text="context.myblock.someText">Honi soit qui mal y pense.</div>';
 		$this->assertSame( $expected_markup, $tags->get_updated_html() );
-		$this->assertSame( $context_before->get_context(), $context->get_context(), 'wp-text directive changed context' );
+		$this->assertSame( $context_before->get_context(), $context->get_context(), 'data-wp-text directive changed context' );
 	}
 }

--- a/src/directives/attributes/wp-html.php
+++ b/src/directives/attributes/wp-html.php
@@ -7,7 +7,7 @@ function process_wp_html( $tags, $context ) {
 		return;
 	}
 
-	$value = $tags->get_attribute( 'wp-html' );
+	$value = $tags->get_attribute( 'data-wp-html' );
 	if ( null === $value ) {
 		return;
 	}

--- a/src/directives/attributes/wp-html.php
+++ b/src/directives/attributes/wp-html.php
@@ -1,0 +1,17 @@
+<?php
+
+require_once __DIR__ . '/../utils.php';
+
+function process_wp_html( $tags, $context ) {
+	if ( $tags->is_tag_closer() ) {
+		return;
+	}
+
+	$value = $tags->get_attribute( 'wp-html' );
+	if ( null === $value ) {
+		return;
+	}
+
+	$text = evaluate( $value, $context->get_context() );
+	$tags->set_inner_html( $text );
+}

--- a/src/directives/attributes/wp-text.php
+++ b/src/directives/attributes/wp-text.php
@@ -13,5 +13,5 @@ function process_wp_text( $tags, $context ) {
 	}
 
 	$text = evaluate( $value, $context->get_context() );
-	$tags->set_inner_html( $text );
+	$tags->set_inner_html( esc_html( $text ) );
 }

--- a/src/directives/attributes/wp-text.php
+++ b/src/directives/attributes/wp-text.php
@@ -7,7 +7,7 @@ function process_wp_text( $tags, $context ) {
 		return;
 	}
 
-	$value = $tags->get_attribute( 'wp-text' );
+	$value = $tags->get_attribute( 'data-wp-text' );
 	if ( null === $value ) {
 		return;
 	}

--- a/src/directives/attributes/wp-text.php
+++ b/src/directives/attributes/wp-text.php
@@ -1,0 +1,17 @@
+<?php
+
+require_once __DIR__ . '/../utils.php';
+
+function process_wp_text( $tags, $context ) {
+	if ( $tags->is_tag_closer() ) {
+		return;
+	}
+
+	$value = $tags->get_attribute( 'wp-text' );
+	if ( null === $value ) {
+		return;
+	}
+
+	$text = evaluate( $value, $context->get_context() );
+	$tags->set_inner_html( $text );
+}

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -45,6 +45,7 @@ require_once __DIR__ . '/src/directives/attributes/wp-bind.php';
 require_once __DIR__ . '/src/directives/attributes/wp-context.php';
 require_once __DIR__ . '/src/directives/attributes/wp-class.php';
 require_once __DIR__ . '/src/directives/attributes/wp-style.php';
+require_once __DIR__ . '/src/directives/attributes/wp-text.php';
 
 function wp_directives_loader() {
 	// Load the Admin page.
@@ -217,6 +218,7 @@ function process_directives_in_block( $block_content ) {
 		'data-wp-bind'    => 'process_wp_bind',
 		'data-wp-class'   => 'process_wp_class',
 		'data-wp-style'   => 'process_wp_style',
+		'data-wp-text'    => 'process_wp_text',
 	);
 
 	$tags = new WP_HTML_Tag_Processor( $block_content );

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -217,6 +217,7 @@ function process_directives_in_block( $block_content ) {
 		'data-wp-context' => 'process_wp_context',
 		'data-wp-bind'    => 'process_wp_bind',
 		'data-wp-class'   => 'process_wp_class',
+		'data-wp-html'    => 'process_wp_html',
 		'data-wp-style'   => 'process_wp_style',
 		'data-wp-text'    => 'process_wp_text',
 	);

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -44,6 +44,7 @@ require_once __DIR__ . '/src/directives/wp-process-directives.php';
 require_once __DIR__ . '/src/directives/attributes/wp-bind.php';
 require_once __DIR__ . '/src/directives/attributes/wp-context.php';
 require_once __DIR__ . '/src/directives/attributes/wp-class.php';
+require_once __DIR__ . '/src/directives/attributes/wp-html.php';
 require_once __DIR__ . '/src/directives/attributes/wp-style.php';
 require_once __DIR__ . '/src/directives/attributes/wp-text.php';
 


### PR DESCRIPTION
Based on #169.

Per my understanding (and the [discussion below](https://github.com/WordPress/block-interactivity-experiments/pull/170#issuecomment-1456583117)), their only difference is that `wp-html` can contain HTML that is used unescaped, whereas `wp-text` escapes its value before rendering it.