### PR TITLE
Require `wp-context.php` file

### DIFF
--- a/wp-directives.php
+++ b/wp-directives.php
@@ -42,6 +42,7 @@ require_once __DIR__ . '/src/directives/class-wp-directive-store.php';
 require_once __DIR__ . '/src/directives/wp-process-directives.php';
 
 require_once __DIR__ . '/src/directives/attributes/wp-bind.php';
+require_once __DIR__ . '/src/directives/attributes/wp-context.php';
 require_once __DIR__ . '/src/directives/attributes/wp-class.php';
 require_once __DIR__ . '/src/directives/attributes/wp-style.php';
 


### PR DESCRIPTION
Right now, we are not requiring the file needed to do the SSR of the `wp-context` directive, so it doesn't work properly. This seems to fix it. Tests are passing because we require it there.