### PR TITLE
Add `wp-text` directive

### DIFF
--- a/e2e/html/directives-text.html
+++ b/e2e/html/directives-text.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Directives -- wp-show</title>
+		<meta itemprop="wp-client-side-navigation" content="active" />
+	</head>
+	<body>
+		<div>
+			<span wp-text="state.text" data-testid="show state text"></span>
+			<button
+				wp-on:click="actions.toggleStateText"
+				data-testid="toggle state text"
+			>
+				Toggle State Text
+			</button>
+		</div>
+
+		<div wp-context='{ "text": "Text 1" }'>
+			<span wp-text="context.text" data-testid="show context text"></span>
+			<button
+				wp-on:click="actions.toggleContextText"
+				data-testid="toggle context text"
+			>
+				Toggle Context Text
+			</button>
+		</div>
+
+		<script src="../build/e2e/store.js"></script>
+		<script src="../build/runtime.js"></script>
+		<script src="../build/vendors.js"></script>
+	</body>
+</html>

--- a/e2e/html/directives-text.html
+++ b/e2e/html/directives-text.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Directives -- wp-show</title>
+		<title>Directives -- wp-text</title>
 		<meta itemprop="wp-client-side-navigation" content="active" />
 	</head>
 	<body>

--- a/e2e/specs/directives-show.spec.ts
+++ b/e2e/specs/directives-show.spec.ts
@@ -6,7 +6,6 @@ test.describe('wp-show', () => {
 	});
 
 	test('show if callback returns truthy value', async ({ page }) => {
-		await page.pause();
 		const el = page.getByTestId('show if callback returns truthy value');
 		await expect(el).toBeVisible();
 	});

--- a/e2e/specs/directives-text.spec.ts
+++ b/e2e/specs/directives-text.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '../tests';
+
+test.describe('wp-text', () => {
+	test.beforeEach(async ({ goToFile }) => {
+		await goToFile('directives-text.html');
+	});
+
+	test('show proper text reading from state', async ({ page }) => {
+		await page.pause();
+		const el = page.getByTestId('show state text');
+		await expect(el).toHaveText("Text 1");
+		page.getByTestId('toggle state text').click();
+		await expect(el).toHaveText("Text 2");
+		page.getByTestId('toggle state text').click();
+		await expect(el).toHaveText("Text 1");
+	});
+
+	test('show proper text reading from context', async ({ page }) => {
+		await page.pause();
+		const el = page.getByTestId('show context text');
+		await expect(el).toHaveText("Text 1");
+		page.getByTestId('toggle context text').click();
+		await expect(el).toHaveText("Text 2");
+		page.getByTestId('toggle context text').click();
+		await expect(el).toHaveText("Text 1");
+	});
+});

--- a/e2e/store.js
+++ b/e2e/store.js
@@ -4,6 +4,7 @@ store({
 	state: {
 		trueValue: true,
 		falseValue: false,
+		text: 'Text 1',
 	},
 	derived: {
 		renderContext: ({ context }) => {
@@ -25,6 +26,16 @@ store({
 			const [key, ...path] = name.split('.').reverse();
 			const obj = path.reduceRight((o, k) => o[k], context);
 			obj[key] = value;
+		},
+		toggleStateText: ({ state }) => {
+			state.text === 'Text 1'
+				? (state.text = 'Text 2')
+				: (state.text = 'Text 1');
+		},
+		toggleContextText: ({ context }) => {
+			context.text === 'Text 1'
+				? (context.text = 'Text 2')
+				: (context.text = 'Text 1');
 		},
 	},
 });

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -198,4 +198,20 @@ export default () => {
 			);
 		}
 	);
+
+	// wp-text
+	directive(
+		'text',
+		({
+			directives: {
+				text: { default: text },
+			},
+			element,
+			evaluate,
+			context,
+		}) => {
+			const contextValue = useContext(context);
+			element.props.children = evaluate(text, { context: contextValue });
+		}
+	);
 };


### PR DESCRIPTION
The goal of this pull request is to add the logic for the `wp-text` directive. It doesn't aim to cover the SSR as, if I am not mistaken, that would be handled in [this other PR](https://github.com/WordPress/block-hydration-experiments/pull/170).

While implementing it I wondered: Should it be possible to use more than one `wp-text` attribute in the same tag? If so, what would it happen? Would they join somehow or they are replaced? _I can move this to another discussion if you believe that's more appropriate_.