### PR TITLE
Change naming from `block-hydration-experiments` to `block-interactivity-experiments`

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,7 +17,7 @@ jobs:
     unit-php:
         name: PHP
         runs-on: ubuntu-latest
-        if: ${{ github.repository == 'WordPress/block-hydration-experiments' || github.event_name == 'pull_request' }}
+        if: ${{ github.repository == 'WordPress/block-interactivity-experiments' || github.event_name == 'pull_request' }}
 
         steps:
             - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -9,7 +9,7 @@
 	"env": {
 		"tests": {
 			"mappings": {
-				"wp-content/plugins/block-hydration-experiments": "."
+				"wp-content/plugins/block-interactivity-experiments": "."
 			}
 		}
 	}

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
-# Block Hydration Experiments
+# Block Interactivity Experiments
 
-This repository aims to explore block hydration patterns with the goal of absorbing as much complexity as possible from the final developers.
+This repository aims to explore block interactivity patterns with the goal of absorbing as much complexity as possible from the final developers.
 
 _It's not a goal to do an in-depth analysis of the patterns, only to experiment with them in a controlled environment to assess their potential and then test them in [the Gutenberg repository](https://github.com/WordPress/gutenberg), where we will see if they are a good fit or not._
 
@@ -9,21 +9,21 @@ _It's not a goal to do an in-depth analysis of the patterns, only to experiment 
 - 🎨 **WordPress Directives Plugin**
 
   - Main branch: `main-wp-directives-plugin` 
-  - Tracking Issue: [Tracking issue: WordPress Directives Plugin 🎨](https://github.com/WordPress/block-hydration-experiments/issues/80)
+  - Tracking Issue: [Tracking issue: WordPress Directives Plugin 🎨](https://github.com/WordPress/block-interactivity-experiments/issues/80)
 
   An installable plugin that adds a set of basic directives and client-side navigation.
 
 - 🧩 **Custom Elements Hydration**
 
   - Main branch: `main-custom-elements-hydration`
-  - Tracking Issue: [Tracking issue: Custom Elements Hydration 🧩](https://github.com/WordPress/block-hydration-experiments/issues/39)
+  - Tracking Issue: [Tracking issue: Custom Elements Hydration 🧩](https://github.com/WordPress/block-interactivity-experiments/issues/39)
 
   This hydration method is based on custom elements (`<wp-block>`) that hydrates isolated islands. It interconnects those islands through synchronized bridges for APIs like `context`, `Suspense` or `ErrorBoundary`.
 
 - ⚛️ **Directives Hydration**
 
   - Main branch: `main-directives-hydration`
-  - Tracking Issue: [Tracking issue: Directives Hydration ⚛](https://github.com/WordPress/block-hydration-experiments/issues/64)
+  - Tracking Issue: [Tracking issue: Directives Hydration ⚛](https://github.com/WordPress/block-interactivity-experiments/issues/64)
 
   This hydration method is based on the creation of a static virtual DOM from the root, where only the interactive islands are replaced by P/React components. It behaves like a single P/React application.
 

--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,18 @@
 {
-	"name": "wordpress/block-hydration-experiments",
+	"name": "wordpress/block-interactivity-experiments",
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
-	"description": "Experiments with frontend hydration for blocks",
+	"description": "Experiments to add interactivity to blocks",
 	"homepage": "https://wordpress.github.io/gutenberg/",
 	"keywords": [
-		"block-hydration-experiments",
+		"block-interactivity-experiments",
 		"wordpress",
 		"wp",
 		"react",
 		"javascript"
 	],
 	"support": {
-		"issues": "https://github.com/WordPress/block-hydration-experiments/issues"
+		"issues": "https://github.com/WordPress/block-interactivity-experiments/issues"
 	},
 	"config": {
 		"process-timeout": 0,

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "wordpress/block-interactivity-experiments",
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
-	"description": "Experiments to add interactivity to blocks",
+	"description": "Experiments to add frontend interactivity to blocks",
 	"homepage": "https://wordpress.github.io/gutenberg/",
 	"keywords": [
 		"block-interactivity-experiments",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "block-hydration-experiments",
+	"name": "block-interactivity-experiments",
 	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
@@ -4760,7 +4760,7 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
 		},
 		"autoprefixer": {
@@ -5482,7 +5482,7 @@
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
 			"dev": true
 		},
 		"clone-deep": {
@@ -6252,7 +6252,7 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
 		"depd": {
@@ -6599,7 +6599,7 @@
 				"levn": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-					"integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+					"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 					"dev": true,
 					"requires": {
 						"prelude-ls": "~1.1.2",
@@ -6623,13 +6623,13 @@
 				"prelude-ls": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-					"integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+					"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 					"dev": true
 				},
 				"type-check": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-					"integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+					"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 					"dev": true,
 					"requires": {
 						"prelude-ls": "~1.1.2"
@@ -7448,7 +7448,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
 			}
@@ -12219,7 +12219,7 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
 		},
 		"p-cancelable": {
@@ -14748,7 +14748,7 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
 		"typedarray-to-buffer": {
@@ -15032,7 +15032,7 @@
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "block-hydration-experiments",
+	"name": "block-interactivity-experiments",
 	"version": "0.1.0",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
@@ -12,7 +12,7 @@
 		"lint:php": "wp-env run composer run-script lint",
 		"test": "jest",
 		"pretest:unit:php": "wp-env start",
-		"test:unit:php": "wp-env run tests-wordpress /var/www/html/wp-content/plugins/block-hydration-experiments/vendor/bin/phpunit -c /var/www/html/wp-content/plugins/block-hydration-experiments/phpunit.xml.dist --verbose",
+		"test:unit:php": "wp-env run tests-wordpress /var/www/html/wp-content/plugins/block-interactivity-experiments/vendor/bin/phpunit -c /var/www/html/wp-content/plugins/block-interactivity-experiments/phpunit.xml.dist --verbose",
 		"test:watch": "jest --watch",
 		"plugin-zip": "wp-scripts plugin-zip",
 		"wp-env": "wp-env"

--- a/src/directives/class-wp-directive-context.php
+++ b/src/directives/class-wp-directive-context.php
@@ -2,7 +2,7 @@
 /**
  * Context data implementation.
  *
- * @package block-hydration-experiments
+ * @package block-interactivity-experiments
  */
 
 /**

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -193,7 +193,7 @@ add_filter( 'render_block', 'wp_directives_mark_interactive_blocks', 10, 3 );
 /**
  * Add a flag to mark inner blocks of isolated interactive blocks.
  */
-function bhe_inner_blocks( $parsed_block, $source_block, $parent_block ) {
+function wp_directives_inner_blocks( $parsed_block, $source_block, $parent_block ) {
 	if (
 		isset( $parent_block ) &&
 		block_has_support(
@@ -208,7 +208,7 @@ function bhe_inner_blocks( $parsed_block, $source_block, $parent_block ) {
 	}
 	return $parsed_block;
 }
-add_filter( 'render_block_data', 'bhe_inner_blocks', 10, 3 );
+add_filter( 'render_block_data', 'wp_directives_inner_blocks', 10, 3 );
 
 function process_directives_in_block( $block_content ) {
 	// TODO: Add some directive/components registration mechanism.


### PR DESCRIPTION
As part of changing the name of the repo to `block-interactivity-experiments` instead of `block-hydration-experiments`, I'm creating this Pull Request to modify the mentions of it in the code.

Once this is done, I believe we can change safely change the name of the repo. According to [the docs](https://docs.github.com/en/repositories/creating-and-managing-repositories/renaming-a-repository):

* All existing information, with the exception of project site URLs, is automatically redirected to the new name.
* All `git clone`, `git fetch`, or `git push` operations targeting the previous location will continue to function. However, they strongly recommend updating it. Users can do this by using `git remote` on the command line:

```
$ git remote set-url origin NEW_URL
```