### PR TITLE
Create GitHub action to bump versions and upload plugin ZIP file

### DIFF
--- a/.github/scripts/build-plugin.js
+++ b/.github/scripts/build-plugin.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const archiver = require('archiver');
+
+// Create a new zip file
+const output = fs.createWriteStream('block-interactivity-experiments.zip');
+const archive = archiver('zip', { zlib: { level: 9 } });
+
+// Add files and directories to the zip file
+archive.directory('src/', 'src');
+archive.directory('build/', 'build');
+archive.file('Readme.md', { name: 'Readme.md' });
+archive.file('wp-directives.php', { name: 'wp-directives.php' });
+
+// Finalize the zip file
+archive.pipe(output);
+archive.finalize();

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -1,0 +1,77 @@
+name: Build Plugin ZIP
+
+on:
+    push:
+        branches:
+            - release-action
+
+jobs:
+    bump-version:
+        runs-on: ubuntu-latest
+        outputs:
+            old_version: ${{ steps.get_version.outputs.old_version }}
+            new_version: ${{ steps.get_version.outputs.new_version }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+              with:
+                  ref: release-action
+
+            - name: Compute old and new version
+              id: get_version
+              run: |
+                  OLD_VERSION=$(jq --raw-output '.version' package.json)
+                  echo "old_version=${OLD_VERSION}" >> $GITHUB_OUTPUT
+                  NEW_VERSION=$(npx semver $OLD_VERSION -i patch)
+                  echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+            - name: Configure git user name and email
+              run: |
+                  git config user.name github-actions[bot]
+                  git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+
+            - name: Update plugin version
+              env:
+                  VERSION: ${{ steps.get_version.outputs.new_version }}
+              run: |
+                  cat <<< $(jq --tab --arg version "${VERSION}" '.version = $version' package.json) > package.json
+                  cat <<< $(jq --tab --arg version "${VERSION}" '.version = $version' package-lock.json) > package-lock.json
+                  sed -i "s/${{ steps.get_version.outputs.old_version }}/${VERSION}/g" wpmovies.php
+
+            - name: Commit the version bump
+              id: commit_version_bump
+              run: |
+                  git add wpmovies.php package.json package-lock.json
+                  git commit -m "Bump plugin version to ${{ steps.get_version.outputs.new_version }}"
+                  git push
+                  echo "version_bump_commit=$(git rev-parse --verify --short HEAD)" >> $GITHUB_OUTPUT
+
+    build:
+        runs-on: ubuntu-latest
+        needs: bump-version
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+              with:
+                  ref: release-action
+
+            - name: Install Composer dependencies
+              run: composer install --no-dev
+
+            - name: Install npm dependencies
+              run: npm ci
+
+            - name: Build plugin
+              run: npm run build
+
+            - name: Create plugin ZIP file
+              run: npm run plugin-zip
+
+            - name: Release
+              uses: softprops/action-gh-release@v1
+              with:
+                  tag_name: ${{ needs.bump-version.outputs.new_version }}
+                  files: |
+                      block-interactivity-experiments.zip

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -37,12 +37,12 @@ jobs:
               run: |
                   cat <<< $(jq --tab --arg version "${VERSION}" '.version = $version' package.json) > package.json
                   cat <<< $(jq --tab --arg version "${VERSION}" '.version = $version' package-lock.json) > package-lock.json
-                  sed -i "s/${{ steps.get_version.outputs.old_version }}/${VERSION}/g" wpmovies.php
+                  sed -i "s/${{ steps.get_version.outputs.old_version }}/${VERSION}/g" wp-directives.php
 
             - name: Commit the version bump
               id: commit_version_bump
               run: |
-                  git add wpmovies.php package.json package-lock.json
+                  git add wp-directives.php package.json package-lock.json
                   git commit -m "Bump plugin version to ${{ steps.get_version.outputs.new_version }}"
                   git push
                   echo "version_bump_commit=$(git rev-parse --verify --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -3,7 +3,7 @@ name: Build Plugin ZIP
 on:
     push:
         branches:
-            - release-action
+            - main
 
 jobs:
     bump-version:
@@ -15,8 +15,6 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v2
-              with:
-                  ref: release-action
 
             - name: Compute old and new version
               id: get_version
@@ -54,8 +52,6 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v2
-              with:
-                  ref: release-action
 
             - name: Install Composer dependencies
               run: composer install --no-dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -4659,6 +4659,52 @@
 				"picomatch": "^2.0.4"
 			}
 		},
+		"archiver": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.1.tgz",
+			"integrity": "sha512-8KyabkmbYrH+9ibcTScQ1xCJC/CGcugdVIwB+53f5sZziXgwUh3iXlAlANMxcZyDEfTHMe6+Z5FofV8nopXP7w==",
+			"dev": true,
+			"requires": {
+				"archiver-utils": "^2.1.0",
+				"async": "^3.2.3",
+				"buffer-crc32": "^0.2.1",
+				"readable-stream": "^3.6.0",
+				"readdir-glob": "^1.0.0",
+				"tar-stream": "^2.2.0",
+				"zip-stream": "^4.1.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.1",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+					"integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
+		"archiver-utils": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+			"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.4",
+				"graceful-fs": "^4.2.0",
+				"lazystream": "^1.0.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.difference": "^4.5.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.union": "^4.6.0",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^2.0.0"
+			}
+		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -4757,10 +4803,16 @@
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
 			"dev": true
 		},
+		"async": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+			"dev": true
+		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
 		},
 		"autoprefixer": {
@@ -5482,7 +5534,7 @@
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
 			"dev": true
 		},
 		"clone-deep": {
@@ -5589,6 +5641,31 @@
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
 			"dev": true
+		},
+		"compress-commons": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.1.tgz",
+			"integrity": "sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==",
+			"dev": true,
+			"requires": {
+				"buffer-crc32": "^0.2.13",
+				"crc32-stream": "^4.0.2",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.1",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+					"integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
 		},
 		"compressible": {
 			"version": "2.0.18",
@@ -5849,6 +5926,35 @@
 				"parse-json": "^5.0.0",
 				"path-type": "^4.0.0",
 				"yaml": "^1.10.0"
+			}
+		},
+		"crc-32": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+			"dev": true
+		},
+		"crc32-stream": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.2.tgz",
+			"integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
+			"dev": true,
+			"requires": {
+				"crc-32": "^1.2.0",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.1",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+					"integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"cross-fetch": {
@@ -6252,7 +6358,7 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
 		"depd": {
@@ -6599,7 +6705,7 @@
 				"levn": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-					"integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+					"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 					"dev": true,
 					"requires": {
 						"prelude-ls": "~1.1.2",
@@ -6623,13 +6729,13 @@
 				"prelude-ls": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-					"integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+					"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 					"dev": true
 				},
 				"type-check": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-					"integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+					"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 					"dev": true,
 					"requires": {
 						"prelude-ls": "~1.1.2"
@@ -7448,7 +7554,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
 			}
@@ -11135,6 +11241,15 @@
 			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
 			"dev": true
 		},
+		"lazystream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+			"integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^2.0.5"
+			}
+		},
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -11210,6 +11325,30 @@
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true
 		},
+		"lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+			"dev": true
+		},
+		"lodash.difference": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+			"integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+			"dev": true
+		},
+		"lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+			"dev": true
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"dev": true
+		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -11226,6 +11365,12 @@
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
 			"integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+			"dev": true
+		},
+		"lodash.union": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+			"integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
 			"dev": true
 		},
 		"lodash.uniq": {
@@ -12219,7 +12364,7 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
 		},
 		"p-cancelable": {
@@ -13145,6 +13290,35 @@
 				"safe-buffer": "~5.1.1",
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
+			}
+		},
+		"readdir-glob": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.2.tgz",
+			"integrity": "sha512-6RLVvwJtVwEDfPdn6X6Ille4/lxGl0ATOY4FN/B9nxQcgOazvvI0nodiD19ScKq0PvA/29VpaOQML36o5IzZWA==",
+			"dev": true,
+			"requires": {
+				"minimatch": "^5.1.0"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "5.1.6",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+					"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				}
 			}
 		},
 		"readdirp": {
@@ -14748,7 +14922,7 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
 		"typedarray-to-buffer": {
@@ -15032,7 +15206,7 @@
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
@@ -15563,6 +15737,30 @@
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true
+		},
+		"zip-stream": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
+			"integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
+			"dev": true,
+			"requires": {
+				"archiver-utils": "^2.1.0",
+				"compress-commons": "^4.1.0",
+				"readable-stream": "^3.6.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.1",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+					"integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "block-hydration-experiments",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "block-hydration-experiments",
-	"version": "0.1.1",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"pretest:unit:php": "wp-env start",
 		"test:unit:php": "wp-env run tests-wordpress /var/www/html/wp-content/plugins/block-hydration-experiments/vendor/bin/phpunit -c /var/www/html/wp-content/plugins/block-hydration-experiments/phpunit.xml.dist --verbose",
 		"test:watch": "jest --watch",
-		"plugin-zip": "wp-scripts plugin-zip",
+		"plugin-zip": "node .github/scripts/build-plugin.js",
 		"wp-env": "wp-env"
 	},
 	"prettier": {
@@ -36,6 +36,7 @@
 		"@types/jest": "^27.5.1",
 		"@wordpress/env": "^5.8.0",
 		"@wordpress/scripts": "^24.3.0",
+		"archiver": "^5.3.1",
 		"babel-jest": "^28.1.0",
 		"jest": "^28.1.0",
 		"prettier": "^2.7.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "block-hydration-experiments",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "block-hydration-experiments",
-	"version": "0.1.1",
+	"version": "0.1.0",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:       wp-directives
- * Version:           0.1.0
+ * Version:           0.1.1
  * Requires at least: 6.0
  * Requires PHP:      5.6
  * Author:            Gutenberg Team

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:       wp-directives
- * Version:           0.1.1
+ * Version:           0.1.0
  * Requires at least: 6.0
  * Requires PHP:      5.6
  * Author:            Gutenberg Team


### PR DESCRIPTION
I'm creating a GitHub action that builds the WP Directive Plugin, bumps the version, and uploads it to the release. This way, it is easily downloadable directly from https://github.com/WordPress/block-hydration-experiments/releases/latest/download/block-interactivity-experiments.zip.

I'm doing the pull request on top of the `build-to-globals` branch because, while creating other plugins like the [WP Movies demo](https://github.com/c4rl0sbr4v0/wp-movies-demo/), they need to access functions like the `store`.

I've created a [fake 0.1.1 release](https://github.com/WordPress/block-hydration-experiments/releases) for testing purposes, and as a way to showcase that files are downloadable. We might need to delete it before merging this Pull Request.