### PR TITLE
Change plugins order in `wp-env` file to activate plugin automatically

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,7 @@
 {
 	"plugins": [
-		".",
-		"https://downloads.wordpress.org/plugin/gutenberg.latest-stable.zip"
+		"https://downloads.wordpress.org/plugin/gutenberg.latest-stable.zip",
+		"."
 	],
 	"config": {
 		"SCRIPT_DEBUG": true


### PR DESCRIPTION
Right now, if you run your local site using `wp-env`, the WP Directive plugin is not activated automatically. This happens because the plugin requires Gutenberg to be installed and we are installing the WP Directives plugin before Gutenberg. Just changing the order in the `.wp-env.json` file should be enough, if I am not mistaken.