### PR TITLE
Change directives notation from colon (" : ") to point (" . ")

### DIFF
--- a/e2e/html/directives-class.html
+++ b/e2e/html/directives-class.html
@@ -6,14 +6,14 @@
 	</head>
 	<body>
 		<button
-			data-wp-on:click="actions.toggleTrueValue"
+			data-wp-on.click="actions.toggleTrueValue"
 			data-testid="toggle trueValue"
 		>
 			Toggle trueValue
 		</button>
 
 		<button
-			data-wp-on:click="actions.toggleFalseValue"
+			data-wp-on.click="actions.toggleFalseValue"
 			data-testid="toggle falseValue"
 		>
 			Toggle falseValue
@@ -21,50 +21,50 @@
 
 		<div
 			class="foo bar"
-			data-wp-class:foo="state.falseValue"
+			data-wp-class.foo="state.falseValue"
 			data-testid="remove class if callback returns falsy value"
 		></div>
 
 		<div
 			class="foo"
-			data-wp-class:bar="state.trueValue"
+			data-wp-class.bar="state.trueValue"
 			data-testid="add class if callback returns truthy value"
 		></div>
 
 		<div
 			class="foo bar"
-			data-wp-class:foo="state.falseValue"
-			data-wp-class:bar="state.trueValue"
-			data-wp-class:baz="state.trueValue"
+			data-wp-class.foo="state.falseValue"
+			data-wp-class.bar="state.trueValue"
+			data-wp-class.baz="state.trueValue"
 			data-testid="handles multiple classes and callbacks"
 		></div>
 
 		<div
 			class="foo foo-bar"
-			data-wp-class:foo="state.falseValue"
-			data-wp-class:foo-bar="state.trueValue"
+			data-wp-class.foo="state.falseValue"
+			data-wp-class.foo-bar="state.trueValue"
 			data-testid="handles class names that are contained inside other class names"
 		></div>
 
 		<div
 			class="foo bar baz"
-			data-wp-class:bar="state.trueValue"
+			data-wp-class.bar="state.trueValue"
 			data-testid="can toggle class in the middle"
 		></div>
 
 		<div
-			data-wp-class:foo="state.falseValue"
+			data-wp-class.foo="state.falseValue"
 			data-testid="can toggle class when class attribute is missing"
 		></div>
 
 		<div data-wp-context='{ "falseValue": false }'>
 			<div
 				class="foo"
-				data-wp-class:foo="context.falseValue"
+				data-wp-class.foo="context.falseValue"
 				data-testid="can use context values"
 			></div>
 			<button
-				data-wp-on:click="actions.toggleContextFalseValue"
+				data-wp-on.click="actions.toggleContextFalseValue"
 				data-testid="toggle context false value"
 			>
 				Toggle context falseValue

--- a/e2e/html/directives-context.html
+++ b/e2e/html/directives-context.html
@@ -11,7 +11,7 @@
 		>
 			<pre
 				data-testid="parent context"
-				data-wp-bind:children="derived.renderContext"
+				data-wp-bind.children="derived.renderContext"
 			>
                 <!-- rendered during hydration -->
             </pre>
@@ -19,7 +19,7 @@
 				data-testid="parent prop1"
 				name="prop1"
 				value="modifiedFromParent"
-				data-wp-on:click="actions.updateContext"
+				data-wp-on.click="actions.updateContext"
 			>
 				prop1
 			</button>
@@ -27,7 +27,7 @@
 				data-testid="parent prop2"
 				name="prop2"
 				value="modifiedFromParent"
-				data-wp-on:click="actions.updateContext"
+				data-wp-on.click="actions.updateContext"
 			>
 				prop2
 			</button>
@@ -35,7 +35,7 @@
 				data-testid="parent obj.prop4"
 				name="obj.prop4"
 				value="modifiedFromParent"
-				data-wp-on:click="actions.updateContext"
+				data-wp-on.click="actions.updateContext"
 			>
 				obj.prop4
 			</button>
@@ -43,7 +43,7 @@
 				data-testid="parent obj.prop5"
 				name="obj.prop5"
 				value="modifiedFromParent"
-				data-wp-on:click="actions.updateContext"
+				data-wp-on.click="actions.updateContext"
 			>
 				obj.prop5
 			</button>
@@ -52,7 +52,7 @@
 			>
 				<pre
 					data-testid="child context"
-					data-wp-bind:children="derived.renderContext"
+					data-wp-bind.children="derived.renderContext"
 				>
                     <!-- rendered during hydration -->
                 </pre>
@@ -60,7 +60,7 @@
 					data-testid="child prop1"
 					name="prop1"
 					value="modifiedFromChild"
-					data-wp-on:click="actions.updateContext"
+					data-wp-on.click="actions.updateContext"
 				>
 					prop1
 				</button>
@@ -68,7 +68,7 @@
 					data-testid="child prop2"
 					name="prop2"
 					value="modifiedFromChild"
-					data-wp-on:click="actions.updateContext"
+					data-wp-on.click="actions.updateContext"
 				>
 					prop2
 				</button>
@@ -76,7 +76,7 @@
 					data-testid="child prop3"
 					name="prop3"
 					value="modifiedFromChild"
-					data-wp-on:click="actions.updateContext"
+					data-wp-on.click="actions.updateContext"
 				>
 					prop3
 				</button>
@@ -84,7 +84,7 @@
 					data-testid="child obj.prop4"
 					name="obj.prop4"
 					value="modifiedFromChild"
-					data-wp-on:click="actions.updateContext"
+					data-wp-on.click="actions.updateContext"
 				>
 					obj.prop4
 				</button>
@@ -92,7 +92,7 @@
 					data-testid="child obj.prop5"
 					name="obj.prop5"
 					value="modifiedFromChild"
-					data-wp-on:click="actions.updateContext"
+					data-wp-on.click="actions.updateContext"
 				>
 					obj.prop5
 				</button>
@@ -100,7 +100,7 @@
 					data-testid="child obj.prop6"
 					name="obj.prop6"
 					value="modifiedFromChild"
-					data-wp-on:click="actions.updateContext"
+					data-wp-on.click="actions.updateContext"
 				>
 					obj.prop6
 				</button>

--- a/e2e/html/directives-show.html
+++ b/e2e/html/directives-show.html
@@ -6,14 +6,14 @@
 	</head>
 	<body>
 		<button
-			data-wp-on:click="actions.toggleTrueValue"
+			data-wp-on.click="actions.toggleTrueValue"
 			data-testid="toggle trueValue"
 		>
 			Toggle trueValue
 		</button>
 
 		<button
-			data-wp-on:click="actions.toggleFalseValue"
+			data-wp-on.click="actions.toggleFalseValue"
 			data-testid="toggle falseValue"
 		>
 			Toggle falseValue
@@ -42,7 +42,7 @@
 				falseValue
 			</div>
 			<button
-				data-wp-on:click="actions.toggleContextFalseValue"
+				data-wp-on.click="actions.toggleContextFalseValue"
 				data-testid="toggle context false value"
 			>
 				Toggle context falseValue

--- a/e2e/html/directives-text.html
+++ b/e2e/html/directives-text.html
@@ -11,7 +11,7 @@
 				data-testid="show state text"
 			></span>
 			<button
-				data-wp-on:click="actions.toggleStateText"
+				data-wp-on.click="actions.toggleStateText"
 				data-testid="toggle state text"
 			>
 				Toggle State Text
@@ -24,7 +24,7 @@
 				data-testid="show context text"
 			></span>
 			<button
-				data-wp-on:click="actions.toggleContextText"
+				data-wp-on.click="actions.toggleContextText"
 				data-testid="toggle context text"
 			>
 				Toggle Context Text

--- a/e2e/html/store-tag-corrupted-json.html
+++ b/e2e/html/store-tag-corrupted-json.html
@@ -9,26 +9,26 @@
 		<div>
 			Counter:
 			<span
-				data-wp-bind:children="state.counter.value"
+				data-wp-bind.children="state.counter.value"
 				data-testid="counter value"
 				>3</span
 			>
 			<br />
 			Double:
 			<span
-				data-wp-bind:children="state.counter.double"
+				data-wp-bind.children="state.counter.double"
 				data-testid="counter double"
 				>6</span
 			>
 			<br />
 			<button
-				data-wp-on:click="actions.counter.increment"
+				data-wp-on.click="actions.counter.increment"
 				data-testid="counter button"
 			>
 				+1
 			</button>
 			<span
-				data-wp-bind:children="state.counter.clicks"
+				data-wp-bind.children="state.counter.clicks"
 				data-testid="counter clicks"
 				>0</span
 			>

--- a/e2e/html/store-tag-invalid-state.html
+++ b/e2e/html/store-tag-invalid-state.html
@@ -9,26 +9,26 @@
 		<div>
 			Counter:
 			<span
-				data-wp-bind:children="state.counter.value"
+				data-wp-bind.children="state.counter.value"
 				data-testid="counter value"
 				>3</span
 			>
 			<br />
 			Double:
 			<span
-				data-wp-bind:children="state.counter.double"
+				data-wp-bind.children="state.counter.double"
 				data-testid="counter double"
 				>6</span
 			>
 			<br />
 			<button
-				data-wp-on:click="actions.counter.increment"
+				data-wp-on.click="actions.counter.increment"
 				data-testid="counter button"
 			>
 				+1
 			</button>
 			<span
-				data-wp-bind:children="state.counter.clicks"
+				data-wp-bind.children="state.counter.clicks"
 				data-testid="counter clicks"
 				>0</span
 			>

--- a/e2e/html/store-tag-missing.html
+++ b/e2e/html/store-tag-missing.html
@@ -9,26 +9,26 @@
 		<div>
 			Counter:
 			<span
-				data-wp-bind:children="state.counter.value"
+				data-wp-bind.children="state.counter.value"
 				data-testid="counter value"
 				>3</span
 			>
 			<br />
 			Double:
 			<span
-				data-wp-bind:children="state.counter.double"
+				data-wp-bind.children="state.counter.double"
 				data-testid="counter double"
 				>6</span
 			>
 			<br />
 			<button
-				data-wp-on:click="actions.counter.increment"
+				data-wp-on.click="actions.counter.increment"
 				data-testid="counter button"
 			>
 				+1
 			</button>
 			<span
-				data-wp-bind:children="state.counter.clicks"
+				data-wp-bind.children="state.counter.clicks"
 				data-testid="counter clicks"
 				>0</span
 			>

--- a/e2e/html/store-tag-ok.html
+++ b/e2e/html/store-tag-ok.html
@@ -9,26 +9,26 @@
 		<div>
 			Counter:
 			<span
-				data-wp-bind:children="state.counter.value"
+				data-wp-bind.children="state.counter.value"
 				data-testid="counter value"
 				>3</span
 			>
 			<br />
 			Double:
 			<span
-				data-wp-bind:children="state.counter.double"
+				data-wp-bind.children="state.counter.double"
 				data-testid="counter double"
 				>6</span
 			>
 			<br />
 			<button
-				data-wp-on:click="actions.counter.increment"
+				data-wp-on.click="actions.counter.increment"
 				data-testid="counter button"
 			>
 				+1
 			</button>
 			<span
-				data-wp-bind:children="state.counter.clicks"
+				data-wp-bind.children="state.counter.clicks"
 				data-testid="counter clicks"
 				>0</span
 			>

--- a/phpunit/directives/attributes/wp-bind.php
+++ b/phpunit/directives/attributes/wp-bind.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/../../../src/directives/wp-html.php';
  */
 class Tests_Directives_WpBind extends WP_UnitTestCase {
 	public function test_directive_sets_attribute() {
-		$markup = '<img data-wp-bind:src="context.myblock.imageSource" />';
+		$markup = '<img data-wp-bind.src="context.myblock.imageSource" />';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
@@ -26,7 +26,7 @@ class Tests_Directives_WpBind extends WP_UnitTestCase {
 		process_wp_bind( $tags, $context );
 
 		$this->assertSame(
-			'<img src="./wordpress.png" data-wp-bind:src="context.myblock.imageSource" />',
+			'<img src="./wordpress.png" data-wp-bind.src="context.myblock.imageSource" />',
 			$tags->get_updated_html()
 		);
 		$this->assertSame( './wordpress.png', $tags->get_attribute( 'src' ) );
@@ -34,7 +34,7 @@ class Tests_Directives_WpBind extends WP_UnitTestCase {
 	}
 
 	public function test_directive_ignores_empty_bound_attribute() {
-		$markup = '<img data-wp-bind:="context.myblock.imageSource" />';
+		$markup = '<img data-wp-bind.="context.myblock.imageSource" />';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 

--- a/phpunit/directives/attributes/wp-class.php
+++ b/phpunit/directives/attributes/wp-class.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/../../../src/directives/wp-html.php';
  */
 class Tests_Directives_WpClass extends WP_UnitTestCase {
 	public function test_directive_adds_class() {
-		$markup = '<div data-wp-class:red="context.myblock.isRed" class="blue">Test</div>';
+		$markup = '<div data-wp-class.red="context.myblock.isRed" class="blue">Test</div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
@@ -26,7 +26,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 		process_wp_class( $tags, $context );
 
 		$this->assertSame(
-			'<div data-wp-class:red="context.myblock.isRed" class="blue red">Test</div>',
+			'<div data-wp-class.red="context.myblock.isRed" class="blue red">Test</div>',
 			$tags->get_updated_html()
 		);
 		$this->assertStringContainsString( 'red', $tags->get_attribute( 'class' ) );
@@ -34,7 +34,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 	}
 
 	public function test_directive_removes_class() {
-		$markup = '<div data-wp-class:blue="context.myblock.isBlue" class="red blue">Test</div>';
+		$markup = '<div data-wp-class.blue="context.myblock.isBlue" class="red blue">Test</div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
@@ -43,7 +43,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 		process_wp_class( $tags, $context );
 
 		$this->assertSame(
-			'<div data-wp-class:blue="context.myblock.isBlue" class="red">Test</div>',
+			'<div data-wp-class.blue="context.myblock.isBlue" class="red">Test</div>',
 			$tags->get_updated_html()
 		);
 		$this->assertStringNotContainsString( 'blue', $tags->get_attribute( 'class' ) );
@@ -51,7 +51,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 	}
 
 	public function test_directive_removes_empty_class_attribute() {
-		$markup = '<div data-wp-class:blue="context.myblock.isBlue" class="blue">Test</div>';
+		$markup = '<div data-wp-class.blue="context.myblock.isBlue" class="blue">Test</div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
@@ -61,7 +61,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 
 		$this->assertSame(
 			// WP_HTML_Tag_Processor has a TODO note to prune whitespace after classname removal.
-			'<div data-wp-class:blue="context.myblock.isBlue" >Test</div>',
+			'<div data-wp-class.blue="context.myblock.isBlue" >Test</div>',
 			$tags->get_updated_html()
 		);
 		$this->assertNull( $tags->get_attribute( 'class' ) );
@@ -69,7 +69,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 	}
 
 	public function test_directive_does_not_remove_non_existant_class() {
-		$markup = '<div data-wp-class:blue="context.myblock.isBlue" class="green red">Test</div>';
+		$markup = '<div data-wp-class.blue="context.myblock.isBlue" class="green red">Test</div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
@@ -78,7 +78,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 		process_wp_class( $tags, $context );
 
 		$this->assertSame(
-			'<div data-wp-class:blue="context.myblock.isBlue" class="green red">Test</div>',
+			'<div data-wp-class.blue="context.myblock.isBlue" class="green red">Test</div>',
 			$tags->get_updated_html()
 		);
 		$this->assertSame( 'green red', $tags->get_attribute( 'class' ) );
@@ -86,7 +86,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 	}
 
 	public function test_directive_ignores_empty_class_name() {
-		$markup = '<div data-wp-class:="context.myblock.isRed" class="blue">Test</div>';
+		$markup = '<div data-wp-class.="context.myblock.isRed" class="blue">Test</div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 

--- a/phpunit/directives/attributes/wp-style.php
+++ b/phpunit/directives/attributes/wp-style.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/../../../src/directives/wp-html.php';
  */
 class Tests_Directives_WpStyle extends WP_UnitTestCase {
 	public function test_directive_adds_style() {
-		$markup = '<div data-wp-style:color="context.myblock.color" style="background: blue;">Test</div>';
+		$markup = '<div data-wp-style.color="context.myblock.color" style="background: blue;">Test</div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
@@ -26,7 +26,7 @@ class Tests_Directives_WpStyle extends WP_UnitTestCase {
 		process_wp_style( $tags, $context );
 
 		$this->assertSame(
-			'<div data-wp-style:color="context.myblock.color" style="background: blue;color: green;">Test</div>',
+			'<div data-wp-style.color="context.myblock.color" style="background: blue;color: green;">Test</div>',
 			$tags->get_updated_html()
 		);
 		$this->assertStringContainsString( 'color: green;', $tags->get_attribute( 'style' ) );
@@ -34,7 +34,7 @@ class Tests_Directives_WpStyle extends WP_UnitTestCase {
 	}
 
 	public function test_directive_ignores_empty_style() {
-		$markup = '<div data-wp-style:="context.myblock.color" style="background: blue;">Test</div>';
+		$markup = '<div data-wp-style.="context.myblock.color" style="background: blue;">Test</div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 

--- a/phpunit/directives/wp-process-directives.php
+++ b/phpunit/directives/wp-process-directives.php
@@ -48,7 +48,7 @@ class Tests_Directives_WpProcessDirectives extends WP_UnitTestCase {
 		wp_process_directives( $tags, 'foo-', $directives );
 	}
 
-	public function test_directives_with_colon_processed_correctly() {
+	public function test_directives_with_dot_processed_correctly() {
 		$test_helper = $this->createMock( Helper_Class::class );
 		$test_helper->expects( $this->atLeastOnce() )
 					->method( 'process_foo_test' );
@@ -57,7 +57,7 @@ class Tests_Directives_WpProcessDirectives extends WP_UnitTestCase {
 			'foo-test' => array( $test_helper, 'process_foo_test' ),
 		);
 
-		$markup = '<div foo-test:value="abc"></div>';
+		$markup = '<div foo-test.value="abc"></div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		wp_process_directives( $tags, 'foo-', $directives );
 	}

--- a/src/directives/attributes/wp-bind.php
+++ b/src/directives/attributes/wp-bind.php
@@ -7,10 +7,10 @@ function process_wp_bind( $tags, $context ) {
 		return;
 	}
 
-	$prefixed_attributes = $tags->get_attribute_names_with_prefix( 'data-wp-bind:' );
+	$prefixed_attributes = $tags->get_attribute_names_with_prefix( 'data-wp-bind.' );
 
 	foreach ( $prefixed_attributes as $attr ) {
-		list( , $bound_attr ) = explode( ':', $attr );
+		list( , $bound_attr ) = explode( '.', $attr );
 		if ( empty( $bound_attr ) ) {
 			continue;
 		}

--- a/src/directives/attributes/wp-class.php
+++ b/src/directives/attributes/wp-class.php
@@ -7,10 +7,10 @@ function process_wp_class( $tags, $context ) {
 		return;
 	}
 
-	$prefixed_attributes = $tags->get_attribute_names_with_prefix( 'data-wp-class:' );
+	$prefixed_attributes = $tags->get_attribute_names_with_prefix( 'data-wp-class.' );
 
 	foreach ( $prefixed_attributes as $attr ) {
-		list( , $class_name ) = explode( ':', $attr );
+		list( , $class_name ) = explode( '.', $attr );
 		if ( empty( $class_name ) ) {
 			continue;
 		}

--- a/src/directives/attributes/wp-style.php
+++ b/src/directives/attributes/wp-style.php
@@ -7,10 +7,10 @@ function process_wp_style( $tags, $context ) {
 		return;
 	}
 
-	$prefixed_attributes = $tags->get_attribute_names_with_prefix( 'data-wp-style:' );
+	$prefixed_attributes = $tags->get_attribute_names_with_prefix( 'data-wp-style.' );
 
 	foreach ( $prefixed_attributes as $attr ) {
-		list( , $style_name ) = explode( ':', $attr );
+		list( , $style_name ) = explode( '.', $attr );
 		if ( empty( $style_name ) ) {
 			continue;
 		}

--- a/src/directives/wp-process-directives.php
+++ b/src/directives/wp-process-directives.php
@@ -27,10 +27,10 @@ function wp_process_directives( $tags, $prefix, $directives ) {
 				}
 			}
 		} else {
-			// Helper that removes the part after the colon before looking
+			// Helper that removes the part after the dot before looking
 			// for the directive processor inside `$attribute_directives`.
 			$get_directive_type = function ( $attr ) {
-				return strtok( $attr, ':' );
+				return strtok( $attr, '.' );
 			};
 
 			$attributes = $tags->get_attribute_names_with_prefix( $prefix );

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -48,7 +48,7 @@ export default () => {
 		}
 	);
 
-	// data-wp-effect:[name]
+	// data-wp-effect.[name]
 	directive('effect', ({ directives: { effect }, context, evaluate }) => {
 		const contextValue = useContext(context);
 		Object.values(effect).forEach((path) => {
@@ -58,7 +58,7 @@ export default () => {
 		});
 	});
 
-	// data-wp-on:[event]
+	// data-wp-on.[event]
 	directive('on', ({ directives: { on }, element, evaluate, context }) => {
 		const contextValue = useContext(context);
 		Object.entries(on).forEach(([name, path]) => {
@@ -68,7 +68,7 @@ export default () => {
 		});
 	});
 
-	// data-wp-class:[classname]
+	// data-wp-class.[classname]
 	directive(
 		'class',
 		({ directives: { class: className }, element, evaluate, context }) => {
@@ -108,7 +108,7 @@ export default () => {
 		}
 	);
 
-	// data-wp-bind:[attribute]
+	// data-wp-bind.[attribute]
 	directive(
 		'bind',
 		({ directives: { bind }, element, context, evaluate }) => {

--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -3,7 +3,7 @@ import { directivePrefix as p } from './constants';
 
 const ignoreAttr = `${p}ignore`;
 const islandAttr = `${p}island`;
-const directiveParser = new RegExp(`${p}([^:]+):?(.*)$`);
+const directiveParser = new RegExp(`${p}([^.]+)\.?(.*)$`);
 
 export const hydratedIslands = new WeakSet();
 


### PR DESCRIPTION
Based on the decision taken https://github.com/WordPress/block-interactivity-experiments/issues/132#issuecomment-1466738441, I'm opening this to handle the notation change. For example, from `data-wp-on:click` to `data-wp-on.click`. I'm doing it on top of https://github.com/WordPress/block-interactivity-experiments/pull/181 because I'm modifying the same lines, and I wanted to avoid merge conflicts. Moreover, they are kind of related. What I did:

- [x] Changed the directiveParser to understand the dot vs the colon.
- [x] Changed the files handling the SSR to handle the dot.
- [x] Update the e2e tests.
- [x] Update the unit tests.