### PR TITLE
Fix `wp-text` directive in SSR

### DIFF
--- a/src/directives/class-wp-directive-processor.php
+++ b/src/directives/class-wp-directive-processor.php
@@ -85,7 +85,7 @@ class WP_Directive_Processor extends WP_HTML_Tag_Processor {
 		list( $start_name, $end_name ) = $bookmarks;
 
 		$start = $this->bookmarks[ $start_name ]->end + 1;
-		$end   = $this->bookmarks[ $end_name ]->start - 1;
+		$end   = $this->bookmarks[ $end_name ]->start;
 
 		$this->seek( $start_name ); // Return to original position.
 		$this->release_bookmark( $start_name );

--- a/src/directives/class-wp-directive-processor.php
+++ b/src/directives/class-wp-directive-processor.php
@@ -85,7 +85,7 @@ class WP_Directive_Processor extends WP_HTML_Tag_Processor {
 		list( $start_name, $end_name ) = $bookmarks;
 
 		$start = $this->bookmarks[ $start_name ]->end + 1;
-		$end   = $this->bookmarks[ $end_name ]->start;
+		$end   = $this->bookmarks[ $end_name ]->start - 1;
 
 		$this->seek( $start_name ); // Return to original position.
 		$this->release_bookmark( $start_name );

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -223,7 +223,7 @@ function process_directives_in_block( $block_content ) {
 		'data-wp-text'    => 'process_wp_text',
 	);
 
-	$tags = new WP_HTML_Tag_Processor( $block_content );
+	$tags = new WP_Directive_Processor( $block_content );
 	$tags = wp_process_directives( $tags, 'data-wp-', $directives );
 	return $tags->get_updated_html();
 }


### PR DESCRIPTION
I was testing the recently added `wp-text` directive in SSR, and it doesn't seem to work in my case. I'm facing two different issues:

* Getting `Uncaught Error: Call to undefined method WP_HTML_Tag_Processor::set_inner_html()`.
* With JavaScript disabled, this is the HTML I'm getting:

<img width="131" alt="Screenshot 2023-03-21 at 10 50 20" src="https://user-images.githubusercontent.com/34552881/226571593-53d62420-36f5-4a57-b707-125f36cd7566.png">

In order to solve that, I made a couple of commits, but I am not sure if it is the best way to solve it:
* In [the `process_directives_in_block` function](https://github.com/WordPress/block-interactivity-experiments/blob/main-wp-directives-plugin/wp-directives.php#L215-L229), I used the `WP_Directive_Processor` class instead of [`WP_HTML_Tag_Processor`](https://github.com/WordPress/block-interactivity-experiments/blob/main-wp-directives-plugin/wp-directives.php#L226), because is the one containing the `set_inner_html` function.
* I changed the end bookmark of the `set_inner_html` function to move one character to the left.

Please, let me know if this is correct and feel free to make any changes needed 🙂 