### PR TITLE
Rename PHP function to `wp_store` instead of `store`

### DIFF
--- a/phpunit/directives/utils/evaluate.php
+++ b/phpunit/directives/utils/evaluate.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/../../../src/directives/utils.php';
 class Tests_Utils_Evaluate extends WP_UnitTestCase {
 	public function test_evaluate_function_should_access_state() {
 		// Init a simple store.
-		store(
+		wp_store(
 			array(
 				'state' => array(
 					'core' => array(

--- a/src/directives/utils.php
+++ b/src/directives/utils.php
@@ -2,7 +2,7 @@
 
 require_once  __DIR__ . '/class-wp-directive-store.php';
 
-function store( $data ) {
+function wp_store( $data ) {
 	WP_Directive_Store::merge_data( $data );
 }
 


### PR DESCRIPTION
As decided [here](https://github.com/WordPress/block-interactivity-experiments/issues/136#issuecomment-1463944790), I'm renaming the PHP function to `wp_store` instead of `store`.