### PR TITLE
Add `replace` option to `navigate`

### DIFF
--- a/e2e/html/csn-page-2.html
+++ b/e2e/html/csn-page-2.html
@@ -28,6 +28,13 @@
 			<p>Show when true</p>
 		</div>
 
+		<button
+			data-wp-on.click="actions.replaceWithPage3"
+			data-testid="replace with page 3"
+		>
+			Replace with page 3
+		</button>
+
 		<script src="../build/e2e/page-2.js"></script>
 		<script src="../build/runtime.js"></script>
 		<script src="../build/vendors.js"></script>

--- a/e2e/html/csn-page-3.html
+++ b/e2e/html/csn-page-3.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>CSN - Page 3</title>
+		<meta itemprop="wp-client-side-navigation" content="active" />
+	</head>
+
+	<body>
+		<h1 data-testid="csn-heading-page-3">Client-side navigation Page 3</h1>
+		<h2 data-testid="csn-subheading">Subheading</h2>
+
+		<script src="../build/runtime.js"></script>
+		<script src="../build/vendors.js"></script>
+	</body>
+</html>

--- a/e2e/page-2/store.js
+++ b/e2e/page-2/store.js
@@ -10,7 +10,6 @@ store({
 			state.newValue = !state.newValue;
 		},
 		replaceWithPage3: () => {
-			debugger;
 			navigate('/csn-page-3.html', { replace: true });
 		},
 	},

--- a/e2e/page-2/store.js
+++ b/e2e/page-2/store.js
@@ -1,4 +1,5 @@
 import { store } from '../../src/runtime/store';
+import { navigate } from '../../src/runtime/router';
 
 store({
 	state: {
@@ -7,6 +8,10 @@ store({
 	actions: {
 		toggleNewValue: ({ state }) => {
 			state.newValue = !state.newValue;
+		},
+		replaceWithPage3: () => {
+			debugger;
+			navigate('/csn-page-3.html', { replace: true });
 		},
 	},
 });

--- a/e2e/specs/csn.spec.ts
+++ b/e2e/specs/csn.spec.ts
@@ -50,4 +50,16 @@ test.describe('toVdom - full', () => {
 		await page.getByTestId('toggle newValue').click();
 		await expect(el).toBeHidden();
 	});
+
+	test('it should replace current page in session history when using `replace` option', async ({
+		page,
+	}) => {
+		await page.getByTestId('csn-next-page').click();
+		await page.getByTestId('replace with page 3').click();
+		const newTitle = page.getByTestId('csn-heading-page-3');
+		await expect(newTitle).toHaveText(/Client-side navigation Page 3/);
+		await page.goBack();
+		const prevTitle = page.getByTestId('csn-heading-page-1');
+		await expect(prevTitle).toHaveText(/Client-side navigation Page 1/);
+	});
 });

--- a/e2e/specs/csn.spec.ts
+++ b/e2e/specs/csn.spec.ts
@@ -54,10 +54,13 @@ test.describe('toVdom - full', () => {
 	test('it should replace current page in session history when using `replace` option', async ({
 		page,
 	}) => {
+		// We start on page 1 and navigate using `push` to page 2.
 		await page.getByTestId('csn-next-page').click();
+		// Once we are in page 2, we navigate using `replace` to page 3.
 		await page.getByTestId('replace with page 3').click();
 		const newTitle = page.getByTestId('csn-heading-page-3');
 		await expect(newTitle).toHaveText(/Client-side navigation Page 3/);
+		// If we go back, we should go back to page 1 and not 2.
 		await page.goBack();
 		const prevTitle = page.getByTestId('csn-heading-page-1');
 		await expect(prevTitle).toHaveText(/Client-side navigation Page 1/);

--- a/e2e/tests.ts
+++ b/e2e/tests.ts
@@ -30,12 +30,7 @@ export const test = base.extend<Fixtures>({
 			const { pathname } = new URL(req.url());
 			route.fulfill({ path: join(__dirname, './html', pathname) });
 		});
-		await page.route('**/*.js', async (route, req) => {
-			const { pathname } = new URL(req.url());
-			route.fulfill({ path: join(__dirname, '..', pathname) });
-		});
-
-		await page.route('**/*.css', async (route, req) => {
+		await page.route('**/*.{js,css}', async (route, req) => {
 			const { pathname } = new URL(req.url());
 			route.fulfill({ path: join(__dirname, '..', pathname) });
 		});

--- a/src/runtime/router.js
+++ b/src/runtime/router.js
@@ -122,8 +122,7 @@ export const navigate = async (href, { replace = false } = {}) => {
 	if (page) {
 		document.head.replaceChildren(...page.head);
 		render(page.body, rootFragment);
-		if (replace) window.history.replaceState({}, '', href);
-		else window.history.pushState({}, '', href);
+		window.history[replace ? "replaceState" : "pushState"]({}, '', href);
 	} else {
 		window.location.assign(href);
 	}

--- a/src/runtime/router.js
+++ b/src/runtime/router.js
@@ -115,14 +115,15 @@ export const prefetch = (url) => {
 };
 
 // Navigate to a new page.
-export const navigate = async (href) => {
+export const navigate = async (href, { replace = false } = {}) => {
 	const url = cleanUrl(href);
 	prefetch(url);
 	const page = await pages.get(url);
 	if (page) {
 		document.head.replaceChildren(...page.head);
 		render(page.body, rootFragment);
-		window.history.pushState({}, '', href);
+		if (replace) window.history.replaceState({}, '', href);
+		else window.history.pushState({}, '', href);
 	} else {
 		window.location.assign(href);
 	}


### PR DESCRIPTION
This PR adds a `replace` option to the router's `navigate` function.

When the option value is `false` (default), the function calls [`history.pushState`](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState).

When set to `true`, it calls [`history.replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState) instead.

The idea of naming that option `replace` is based on what React Router does for its [`navigate`](https://reactrouter.com/en/main/hooks/use-navigate#type-declaration), or Next.js does for its [`Link`](https://nextjs.org/docs/api-reference/next/link#replace-the-url-instead-of-push) component.

