### PR TITLE
Remove type from prop inside `WP_Directive_Store`

### DIFF
--- a/src/directives/class-wp-directive-store.php
+++ b/src/directives/class-wp-directive-store.php
@@ -1,7 +1,7 @@
 <?php
 
 class WP_Directive_Store {
-	private static array $store = array();
+	private static $store = array();
 
 	static function get_data() {
 		return self::$store;


### PR DESCRIPTION
[Typed properties](https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.typed-properties) inside classes is a feature introduced in PHP 7.4.

The latest WordPress version (6.1) supports PHP 5.6, so it'd be better to stop using typed properties.