### PR TITLE
Add a link to the Interactivity API blog post

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,4 +39,4 @@ If you want to use these experiments on your blocks, they will need:
 
 Feel free to clone this repository and inspect the code, open issues, submit PRs, suggest features or ask questions!
 
-And if you are doing any other frontend-related work, please leave a comment in this [Make Core post](https://make.wordpress.org/core/2022/04/27/exploration-to-enable-better-developer-and-visitor-experiences-with-blocks/).
+And if you are doing any other frontend-related work, please leave a comment in this [Make Core post](https://make.wordpress.org/core/2023/03/30/proposal-the-interactivity-api-a-better-developer-experience-in-building-interactive-blocks/).


### PR DESCRIPTION
Add a link to the [Interactivity API Proposal blog post](https://make.wordpress.org/core/2023/03/30/proposal-the-interactivity-api-a-better-developer-experience-in-building-interactive-blocks/).

I'm also open to featuring it more prominently in the README!