### PR TITLE
Implement `next_directive` in `WP_Directive_Processor`

### DIFF
--- a/phpunit/directives/wp-process-directives.php
+++ b/phpunit/directives/wp-process-directives.php
@@ -5,7 +5,7 @@
 
 require_once __DIR__ . '/../../src/directives/wp-process-directives.php';
 
-require_once __DIR__ . '/../../src/directives/wp-html.php';
+require_once __DIR__ . '/../../src/directives/class-wp-directive-processor.php';
 
 class Helper_Class {
 	function process_foo_test( $tags, $context ) {
@@ -44,7 +44,7 @@ class Tests_Directives_WpProcessDirectives extends WP_UnitTestCase {
 		);
 
 		$markup = '<div>Example: <div foo-test="abc"><img><span>This is a test></span><div>Here is a nested div</div></div></div>';
-		$tags   = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_Directive_Processor( $markup, 'foo-' );
 		wp_process_directives( $tags, 'foo-', $directives );
 	}
 
@@ -58,7 +58,7 @@ class Tests_Directives_WpProcessDirectives extends WP_UnitTestCase {
 		);
 
 		$markup = '<div foo-test.value="abc"></div>';
-		$tags   = new WP_HTML_Tag_Processor( $markup );
+		$tags   = new WP_Directive_Processor( $markup, 'foo-' );
 		wp_process_directives( $tags, 'foo-', $directives );
 	}
 }

--- a/src/directives/wp-process-directives.php
+++ b/src/directives/wp-process-directives.php
@@ -23,14 +23,8 @@ function wp_process_directives( $tags, $prefix, $directives ) {
 	$context = new WP_Directive_Context;
 
 	while ( $tags->next_directive() ) {
-		// Helper that removes the part after the dot before looking
-		// for the directive processor inside `$attribute_directives`.
-		$get_directive_type = function ( $attr ) {
-			return strtok( $attr, '.' );
-		};
-
-		$attributes = $tags->get_directive_names();
-		$attributes = array_intersect( $attributes, array_keys( $directives ) );
+		$directive_attributes = $tags->get_directive_names();
+		$attributes           = array_intersect( $directive_attributes, array_keys( $directives ) );
 
 		foreach ( $attributes as $attribute ) {
 			call_user_func( $directives[ $attribute ], $tags, $context );

--- a/src/directives/wp-process-directives.php
+++ b/src/directives/wp-process-directives.php
@@ -22,48 +22,15 @@ require_once __DIR__ . '/class-wp-directive-processor.php';
 function wp_process_directives( $tags, $prefix, $directives ) {
 	$context = new WP_Directive_Context;
 
-	$tag_stack = array();
-	while ( $tags->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
-		$tag_name = strtolower( $tags->get_tag() );
+	while ( $tags->next_directive() ) {
+		// Helper that removes the part after the dot before looking
+		// for the directive processor inside `$attribute_directives`.
+		$get_directive_type = function ( $attr ) {
+			return strtok( $attr, '.' );
+		};
 
-		// Is this a tag that closes the latest opening tag?
-		if ( $tags->is_tag_closer() ) {
-			if ( 0 === count( $tag_stack ) ) {
-				continue;
-			}
-
-			list( $latest_opening_tag_name, $attributes ) = end( $tag_stack );
-			if ( $latest_opening_tag_name === $tag_name ) {
-				array_pop( $tag_stack );
-
-				// If the matching opening tag didn't have any attribute directives,
-				// we move on.
-				if ( 0 === count( $attributes ) ) {
-					continue;
-				}
-			}
-		} else {
-			// Helper that removes the part after the dot before looking
-			// for the directive processor inside `$attribute_directives`.
-			$get_directive_type = function ( $attr ) {
-				return strtok( $attr, '.' );
-			};
-
-			$attributes = $tags->get_attribute_names_with_prefix( $prefix );
-			$attributes = array_map( $get_directive_type, $attributes );
-			$attributes = array_intersect( $attributes, array_keys( $directives ) );
-
-			// If this is an open tag, and if it either has attribute directives,
-			// or if we're inside a tag that does, take note of this tag and its attribute
-			// directives so we can call its directive processor once we encounter the
-			// matching closing tag.
-			if (
-				! WP_Directive_Processor::is_html_void_element( $tags->get_tag() ) &&
-				( 0 !== count( $attributes ) || 0 !== count( $tag_stack ) )
-			) {
-				$tag_stack[] = array( $tag_name, $attributes );
-			}
-		}
+		$attributes = $tags->get_directive_names();
+		$attributes = array_intersect( $attributes, array_keys( $directives ) );
 
 		foreach ( $attributes as $attribute ) {
 			call_user_func( $directives[ $attribute ], $tags, $context );


### PR DESCRIPTION
WIP.

TODO:
- [ ] Store bookmarks to open tags in `$this->tag_stack`.
- [ ] Add new method (or logic) to go to matching opener when on a closer.
- [ ] Replace calls to `next_tag` with `next_directive`.

This will allow directive processors (iterative or recursive) to easily locate the opener. We might want to split our current directive processors into an opener and an optional closer, e.g.

```
	$directives = array(
		'data-wp-context' => array( 'process_wp_context_opener', `process_wp_context_closer` ),
		'data-wp-bind'    => 'process_wp_bind',
		// etc
	);
```

We can then try to implement the recursive way.