### PR TITLE
wp-bind improvements and negation in runtime

### DIFF
--- a/e2e/html/directive-bind.html
+++ b/e2e/html/directive-bind.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Directives -- data-wp-bind</title>
+		<meta itemprop="wp-client-side-navigation" content="active" />
+	</head>
+	<body>
+		<a
+			data-wp-bind.href="state.url"
+			data-testid="add missing href at hydration"
+		></a>
+
+		<a
+			href="/other-url"
+			data-wp-bind.href="state.url"
+			data-testid="change href at hydration"
+		></a>
+
+		<input
+			type="checkbox"
+			data-wp-bind.checked="state.checked"
+			data-testid="add missing checked at hydration"
+		/>
+
+		<input
+			type="checkbox"
+			checked
+			data-wp-bind.checked="!state.checked"
+			data-testid="remove existing checked at hydration"
+		/>
+
+		<button data-testid="toggle" data-wp-on.click="actions.toggle">
+			Update
+		</button>
+
+		<script src="../../build/e2e/html/directive-bind.js"></script>
+		<script src="../../build/runtime.js"></script>
+		<script src="../../build/vendors.js"></script>
+	</body>
+</html>

--- a/e2e/html/directive-bind.js
+++ b/e2e/html/directive-bind.js
@@ -1,0 +1,15 @@
+import { store } from '../../src/runtime/store';
+
+// State for the store hydration tests.
+store({
+	state: {
+		url: '/some-url',
+		checked: true,
+	},
+	actions: {
+		toggle: ({ state }) => {
+			state.url = '/some-other-url';
+			state.checked = !state.checked;
+		},
+	},
+});

--- a/e2e/specs/directive-bind.spec.ts
+++ b/e2e/specs/directive-bind.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '../tests';
+
+test.describe('data-wp-bind', () => {
+	test.beforeEach(async ({ goToFile }) => {
+		await goToFile('directive-bind.html');
+	});
+
+	test('add missing href at hydration', async ({ page }) => {
+		const el = page.getByTestId('add missing href at hydration');
+		await expect(el).toHaveAttribute('href', '/some-url');
+	});
+
+	test('change href at hydration', async ({ page }) => {
+		const el = page.getByTestId('change href at hydration');
+		await expect(el).toHaveAttribute('href', '/some-url');
+	});
+
+	test('update missing href at hydration', async ({ page }) => {
+		const el = page.getByTestId('add missing href at hydration');
+		await expect(el).toHaveAttribute('href', '/some-url');
+		page.getByTestId('toggle').click();
+		await expect(el).toHaveAttribute('href', '/some-other-url');
+	});
+
+	test('add missing checked at hydration', async ({ page }) => {
+		const el = page.getByTestId('add missing checked at hydration');
+		await expect(el).toHaveAttribute('checked', '');
+	});
+
+	test('remove existing checked at hydration', async ({ page }) => {
+		const el = page.getByTestId('remove existing checked at hydration');
+		await expect(el).not.toHaveAttribute('checked', '');
+	});
+
+	test('update existing checked', async ({ page }) => {
+		const el = page.getByTestId('add missing checked at hydration');
+		const el2 = page.getByTestId('remove existing checked at hydration');
+		let checked = await el.evaluate(
+			(element: HTMLInputElement) => element.checked
+		);
+		let checked2 = await el2.evaluate(
+			(element: HTMLInputElement) => element.checked
+		);
+		expect(checked).toBe(true);
+		expect(checked2).toBe(false);
+		await page.getByTestId('toggle').click();
+		checked = await el.evaluate(
+			(element: HTMLInputElement) => element.checked
+		);
+		checked2 = await el2.evaluate(
+			(element: HTMLInputElement) => element.checked
+		);
+		expect(checked).toBe(false);
+		expect(checked2).toBe(true);
+	});
+});

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -116,9 +116,22 @@ export default () => {
 			Object.entries(bind)
 				.filter((n) => n !== 'default')
 				.forEach(([attribute, path]) => {
-					element.props[attribute] = evaluate(path, {
+					const result = evaluate(path, {
 						context: contextValue,
 					});
+					element.props[attribute] = result;
+
+					useEffect(() => {
+						// This seems necessary because Preact doesn't change the attributes
+						// on the hydration, so we have to do it manually. It doesn't need
+						// deps because it only needs to do it the first time.
+						result === false
+							? element.ref.current.removeAttribute(attribute)
+							: element.ref.current.setAttribute(
+									attribute,
+									result === true ? '' : result
+							  );
+					}, []);
 				});
 		}
 	);

--- a/src/runtime/hooks.js
+++ b/src/runtime/hooks.js
@@ -20,9 +20,11 @@ export const component = (name, Comp) => {
 
 // Resolve the path to some property of the store object.
 const resolve = (path, context) => {
+	// If path starts with !, remove it and save a flag.
+	const isNegative = path[0] === '!' && !!(path = path.slice(1));
 	let current = { ...store, context };
 	path.split('.').forEach((p) => (current = current[p]));
-	return current;
+	return isNegative ? !current : current;
 };
 
 // Generate the evaluate function.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = [
 			runtime: './src/runtime',
 			'e2e/page-1': './e2e/page-1',
 			'e2e/page-2': './e2e/page-2',
+			'e2e/html/directive-bind': './e2e/html/directive-bind',
 		},
 		output: {
 			filename: '[name].js',


### PR DESCRIPTION
## What

- I've added support for negations to the JavaScript runtime: `data-wp-bind.checked="!state.checked"`.
- I've improved `data-wp-bind` to modify attributes on hydration (Preact doesn't modify them when using `hydrate`).
- I've added e2e tests for `data-wp-bind`, including one that uses `"!state.checked"`.


## Why

Because `!` is easy enough to add, and it's very useful when combined with `data-wp-show` or `data-wp-bind.hidden` (if/else).

## How

- For the negation, just check if the path starts with `!`.
- For the `data-wp-bind`, add a `useEffect` and change the DOM manually to reflect the vDOM (similar to `data-wp-class`).

## Notes

1. While working on `data-wp-bind.checked`, I stumbled upon this weird thing: When you change the `checked` attribute of a node with React ([reproduced here](https://stackblitz.com/edit/vitejs-vite-yyynmq?file=index.html,src%2Fmain.jsx&terminal=dev)) or Preact ([reproduced here](https://stackblitz.com/edit/vitejs-vite-ph3ck3?file=src%2Fmain.jsx,index.html&terminal=dev)), the browser doesn't update the `checked` attribute of the component. Everything seems to work because `element.checked` is correct and [Dan says this is correct way of doing it](https://github.com/facebook/react/issues/24439), but at first it's pretty confusing 😅
2. I'll work on the server-side negation in another PR.