### PR TITLE
Add server side negation operator

### DIFF
--- a/phpunit/directives/utils/evaluate.php
+++ b/phpunit/directives/utils/evaluate.php
@@ -12,45 +12,48 @@ require_once __DIR__ . '/../../../src/directives/utils.php';
  * @covers evaluate
  */
 class Tests_Utils_Evaluate extends WP_UnitTestCase {
-	public function test_evaluate_function_should_access_state() {
-		// Init a simple store.
-		wp_store(
-			array(
-				'state' => array(
-					'core' => array(
-						'number' => 1,
-						'bool'   => true,
-						'nested' => array(
-							'string' => 'hi',
-						),
-					),
-				),
-			)
-		);
-		$this->assertSame( 1, evaluate( 'state.core.number' ) );
-		$this->assertTrue( evaluate( 'state.core.bool' ) );
-		$this->assertSame( 'hi', evaluate( 'state.core.nested.string' ) );
-	}
-	public function test_evaluate_function_should_access_passed_context() {
-		$context = array(
-			'local' => array(
-				'number' => 2,
-				'bool'   => false,
-				'nested' => array(
-					'string' => 'bye',
-				),
-			),
-		);
-		$this->assertSame( 2, evaluate( 'context.local.number', $context ) );
-		$this->assertFalse( evaluate( 'context.local.bool', $context ) );
-		$this->assertSame( 'bye', evaluate( 'context.local.nested.string', $context ) );
-		// Previous defined state is also accessible.
-		$this->assertSame( 1, evaluate( 'state.core.number' ) );
-		$this->assertTrue( evaluate( 'state.core.bool' ) );
-		$this->assertSame( 'hi', evaluate( 'state.core.nested.string' ) );
-	}
+		public function test_evaluate_function_should_access_state() {
+				// Init a simple store.
+				wp_store(
+						array(
+								'state' => array(
+										'core' => array(
+												'number' => 1,
+												'bool'   => true,
+												'nested' => array(
+														'string' => 'hi',
+												),
+										),
+								),
+						)
+				);
+				$this->assertSame( 1, evaluate( 'state.core.number' ) );
+				$this->assertTrue( evaluate( 'state.core.bool' ) );
+				$this->assertSame( 'hi', evaluate( 'state.core.nested.string' ) );
+				$this->assertFalse( evaluate( '!state.core.bool' ) );
+		}
 
-	public function test_evaluate_function_should_return_null_for_unresolved_paths() {
-		$this->assertNull( evaluate( 'this.property.doesnt.exist' ) );
-	}
+		public function test_evaluate_function_should_access_passed_context() {
+				$context = array(
+						'local' => array(
+								'number' => 2,
+								'bool'   => false,
+								'nested' => array(
+										'string' => 'bye',
+								),
+						),
+				);
+				$this->assertSame( 2, evaluate( 'context.local.number', $context ) );
+				$this->assertFalse( evaluate( 'context.local.bool', $context ) );
+				$this->assertTrue( evaluate( '!context.local.bool', $context ) );
+				$this->assertSame( 'bye', evaluate( 'context.local.nested.string', $context ) );
+				// Previously defined state is also accessible.
+				$this->assertSame( 1, evaluate( 'state.core.number' ) );
+				$this->assertTrue( evaluate( 'state.core.bool' ) );
+				$this->assertSame( 'hi', evaluate( 'state.core.nested.string' ) );
+		}
+
+		public function test_evaluate_function_should_return_null_for_unresolved_paths() {
+				$this->assertNull( evaluate( 'this.property.doesnt.exist' ) );
+		}
 }

--- a/phpunit/directives/utils/evaluate.php
+++ b/phpunit/directives/utils/evaluate.php
@@ -12,48 +12,48 @@ require_once __DIR__ . '/../../../src/directives/utils.php';
  * @covers evaluate
  */
 class Tests_Utils_Evaluate extends WP_UnitTestCase {
-		public function test_evaluate_function_should_access_state() {
-				// Init a simple store.
-				wp_store(
-						array(
-								'state' => array(
-										'core' => array(
-												'number' => 1,
-												'bool'   => true,
-												'nested' => array(
-														'string' => 'hi',
-												),
-										),
-								),
-						)
-				);
-				$this->assertSame( 1, evaluate( 'state.core.number' ) );
-				$this->assertTrue( evaluate( 'state.core.bool' ) );
-				$this->assertSame( 'hi', evaluate( 'state.core.nested.string' ) );
-				$this->assertFalse( evaluate( '!state.core.bool' ) );
-		}
-
-		public function test_evaluate_function_should_access_passed_context() {
-				$context = array(
-						'local' => array(
-								'number' => 2,
-								'bool'   => false,
-								'nested' => array(
-										'string' => 'bye',
-								),
+	public function test_evaluate_function_should_access_state() {
+		// Init a simple store.
+		wp_store(
+			array(
+				'state' => array(
+					'core' => array(
+						'number' => 1,
+						'bool'   => true,
+						'nested' => array(
+							'string' => 'hi',
 						),
-				);
-				$this->assertSame( 2, evaluate( 'context.local.number', $context ) );
-				$this->assertFalse( evaluate( 'context.local.bool', $context ) );
-				$this->assertTrue( evaluate( '!context.local.bool', $context ) );
-				$this->assertSame( 'bye', evaluate( 'context.local.nested.string', $context ) );
-				// Previously defined state is also accessible.
-				$this->assertSame( 1, evaluate( 'state.core.number' ) );
-				$this->assertTrue( evaluate( 'state.core.bool' ) );
-				$this->assertSame( 'hi', evaluate( 'state.core.nested.string' ) );
-		}
+					),
+				),
+			)
+		);
+		$this->assertSame( 1, evaluate( 'state.core.number' ) );
+		$this->assertTrue( evaluate( 'state.core.bool' ) );
+		$this->assertSame( 'hi', evaluate( 'state.core.nested.string' ) );
+		$this->assertFalse( evaluate( '!state.core.bool' ) );
+	}
 
-		public function test_evaluate_function_should_return_null_for_unresolved_paths() {
-				$this->assertNull( evaluate( 'this.property.doesnt.exist' ) );
-		}
+	public function test_evaluate_function_should_access_passed_context() {
+		$context = array(
+			'local' => array(
+				'number' => 2,
+				'bool'   => false,
+				'nested' => array(
+					'string' => 'bye',
+				),
+			),
+		);
+		$this->assertSame( 2, evaluate( 'context.local.number', $context ) );
+		$this->assertFalse( evaluate( 'context.local.bool', $context ) );
+		$this->assertTrue( evaluate( '!context.local.bool', $context ) );
+		$this->assertSame( 'bye', evaluate( 'context.local.nested.string', $context ) );
+		// Previously defined state is also accessible.
+		$this->assertSame( 1, evaluate( 'state.core.number' ) );
+		$this->assertTrue( evaluate( 'state.core.bool' ) );
+		$this->assertSame( 'hi', evaluate( 'state.core.nested.string' ) );
+	}
+
+	public function test_evaluate_function_should_return_null_for_unresolved_paths() {
+		$this->assertNull( evaluate( 'this.property.doesnt.exist' ) );
+	}
 }

--- a/src/directives/utils.php
+++ b/src/directives/utils.php
@@ -27,27 +27,27 @@ function wp_store( $data ) {
  * @return mixed
  */
 function evaluate( $path, array $context = array() ) {
-		$current = array_merge(
-				WP_Directive_Store::get_data(),
-				array( 'context' => $context )
-		);
+	$current = array_merge(
+		WP_Directive_Store::get_data(),
+		array( 'context' => $context )
+	);
 
-		if ( strpos( $path, '!' ) === 0 ) {
-				$path = substr( $path, 1 );
-				$opposite = true;
+	if ( strpos( $path, '!' ) === 0 ) {
+		$path     = substr( $path, 1 );
+		$opposite = true;
+	}
+
+	$array = explode( '.', $path );
+
+	foreach ( $array as $p ) {
+		if ( isset( $current[ $p ] ) ) {
+			$current = $current[ $p ];
+		} else {
+			return null;
 		}
+	}
 
-		$array = explode( '.', $path );
-
-		foreach ( $array as $p ) {
-				if ( isset( $current[ $p ] ) ) {
-						$current = $current[ $p ];
-				} else {
-						return null;
-				}
-		}
-
-		return isset( $opposite ) ? ! $current : $current;
+	return isset( $opposite ) ? ! $current : $current;
 }
 
 

--- a/src/directives/utils.php
+++ b/src/directives/utils.php
@@ -27,21 +27,29 @@ function wp_store( $data ) {
  * @return mixed
  */
 function evaluate( $path, array $context = array() ) {
-	$current = array_merge(
-		WP_Directive_Store::get_data(),
-		array( 'context' => $context )
-	);
+		$current = array_merge(
+				WP_Directive_Store::get_data(),
+				array( 'context' => $context )
+		);
 
-	$array = explode( '.', $path );
-	foreach ( $array as $p ) {
-		if ( isset( $current[ $p ] ) ) {
-			$current = $current[ $p ];
-		} else {
-			return null;
+		if ( strpos( $path, '!' ) === 0 ) {
+				$path = substr( $path, 1 );
+				$opposite = true;
 		}
-	}
-	return $current;
+
+		$array = explode( '.', $path );
+
+		foreach ( $array as $p ) {
+				if ( isset( $current[ $p ] ) ) {
+						$current = $current[ $p ];
+				} else {
+						return null;
+				}
+		}
+
+		return isset( $opposite ) ? ! $current : $current;
 }
+
 
 /**
  * Set style.

--- a/src/directives/utils.php
+++ b/src/directives/utils.php
@@ -33,8 +33,8 @@ function evaluate( $path, array $context = array() ) {
 	);
 
 	if ( strpos( $path, '!' ) === 0 ) {
-		$path     = substr( $path, 1 );
-		$opposite = true;
+		$path                  = substr( $path, 1 );
+		$has_negation_operator = true;
 	}
 
 	$array = explode( '.', $path );
@@ -47,7 +47,7 @@ function evaluate( $path, array $context = array() ) {
 		}
 	}
 
-	return isset( $opposite ) ? ! $current : $current;
+	return isset( $has_negation_operator ) ? ! $current : $current;
 }
 
 

--- a/src/runtime/hooks.js
+++ b/src/runtime/hooks.js
@@ -21,10 +21,10 @@ export const component = (name, Comp) => {
 // Resolve the path to some property of the store object.
 const resolve = (path, context) => {
 	// If path starts with !, remove it and save a flag.
-	const isNegative = path[0] === '!' && !!(path = path.slice(1));
+	const hasNegationOperator = path[0] === '!' && !!(path = path.slice(1));
 	let current = { ...store, context };
 	path.split('.').forEach((p) => (current = current[p]));
-	return isNegative ? !current : current;
+	return hasNegationOperator ? !current : current;
 };
 
 // Generate the evaluate function.


### PR DESCRIPTION
## What

The server-side part of the `!` operator introduced in https://github.com/WordPress/block-interactivity-experiments/pull/213.

## Why

Because the server also needs to understand it.

## How

Just replicate the JavaScript logic, check for the presence of `!` at the start of the $path and return the opposite if it's found.
