### PR TITLE
SSR: Fix directive processor invocation

### DIFF
--- a/src/directives/wp-process-directives.php
+++ b/src/directives/wp-process-directives.php
@@ -68,6 +68,7 @@ function wp_process_directives( $tags, $prefix, $directives ) {
 		foreach ( $attributes as $attribute ) {
 			call_user_func( $directives[ $attribute ], $tags, $context );
 		}
+		$tags->get_updated_html();
 	}
 
 	return $tags;

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -233,28 +233,39 @@ add_filter( 'render_block', 'wp_directives_mark_interactive_blocks', 10, 3 );
  */
 function wp_directives_inner_blocks( $parsed_block, $source_block, $parent_block ) {
 	if (
-		isset( $parent_block ) &&
-		block_has_support(
-			$parent_block->block_type,
-			array(
-				'interactivity',
-				'isolated',
-			)
-		)
+		isset( $parent_block )
 	) {
-		$parsed_block['isolated'] = true;
+		if (
+			block_has_support(
+				$parent_block->block_type,
+				array(
+					'interactivity',
+					'isolated',
+				)
+			)
+		) {
+			$parsed_block['isolated'] = true;
+		}
+		$parsed_block['inner_block'] = true;
 	}
 	return $parsed_block;
 }
 add_filter( 'render_block_data', 'wp_directives_inner_blocks', 10, 3 );
 
+
 /**
  * Process directives in block.
  *
- * @param string $block_content Block content.
+ * @param string   $block_content Block content.
+ * @param array    $block Block.
+ * @param WP_Block $instance Block instance.
  * @return string Filtered block content.
  */
-function process_directives_in_block( $block_content ) {
+function process_directives_in_block( $block_content, $block, $instance ) {
+	if ( isset( $instance->parsed_block['inner_block'] ) ) {
+		return $block_content;
+	}
+
 	// TODO: Add some directive/components registration mechanism.
 	$directives = array(
 		'data-wp-context' => 'process_wp_context',
@@ -273,7 +284,7 @@ add_filter(
 	'render_block',
 	'process_directives_in_block',
 	10,
-	1
+	3
 );
 
 // TODO: check if priority 9 is enough.


### PR DESCRIPTION
There are currently two problems with the way we invoke our directive SSR processors:

1. Since we are [hooking `wp_process_directives` into `render_block`](https://github.com/WordPress/block-interactivity-experiments/blob/00f7825934ec58ed6482c2a7548f73a27d65f838/wp-directives.php#L251-L277), it gets run repeatedly on markup inside nested inner blocks (once for each level of block nesting around a given piece of markup).
2. After invoking all relevant directive processors on a given tag, we just move on via `next_tag()`, without flushing the changes made to the current tag.

Any issues arising from these remained undiscovered until #141, which introduces the `data-wp-show` directive. The latter is a bit special in that it wraps a tag with said directive in a `<template>` tag (if the directive attribute value is falsy), and moves the `data-wp-show` directive to that newly prepended `<template>`).

### Instructions to reproduce the issue(s)

The following issues were observed when running the [`wp-movies-demo` repo](https://github.com/WordPress/wp-movies-demo) locally in connection with a local copy of the `block-interactivity-experiments` repo, with the `add/wp-show-ssr` branch (from #141) checked out.

<details>
<summary>
To do the latter, you can create a file named `.wp-env.override.json` in the `wp-movies-demo` root with these contents
</summary>

```json
{
    "plugins": [
        "https://downloads.wordpress.org/plugin/gutenberg.latest-stable.zip",
        "https://downloads.wordpress.org/plugin/wordpress-importer.latest-stable.zip",
        "../block-interactivity-experiments",
        "."
    ]
}
```

</details>

Because of the aforementioned issues, we would then encounter markup such as https://github.com/WordPress/block-interactivity-experiments/pull/141#issuecomment-1481056217:

```html
<template>
  <template data-wp-show="falseValue">
    <template>
      <div>
        <span>WP Show</span>
      </div>
    </template>
  </template>
</template>
```

Note the three nested `<template>`s -- two of them are due to the fact that the block that contains the `data-wp-show` directive is nested in another block. Finally, the outermost `<template>` is due to the fact that another directive (`data-wp-class` is present and processed before `data-wp-show`, without flushing (i.e. calling `get_updated_html()`) prior to invoking the `data-wp-show` directive processor.

This PR aims to fix both issues. To verify, follow the above instructions to reproduce the issue.
Then, on top of the `add/wp-show-ssr` branch, apply the changes from _this_ branch (e.g. by merging this branch into it, or by cherry-picking the commits), and test again. The markup should now be fixed:

```html
<template data-wp-show="falseValue">
  <div>
    <span>WP Show</span>
  </div>
</template>
```

### Automated test coverage, or the lack thereof

It's unfortunately a bit hard to add proper unit test coverage for this -- arguable as it's more of an integration problem (that would require integration tests).

In the process of investigating this issue, I added some tests to #141 to reproduce issue number 2 ([e.g.](https://github.com/WordPress/block-interactivity-experiments/pull/141/commits/04da5ca33437555a4dfb32d61aed0ea56eb2d02e)), but they can't really count as unit tests: While they helped detecting the issue, we cannot make them pass by applying the code changes from this PR; instead, we'd need to add `get_updated_html()` calls right inside test (after `add_class`, before `next_tag`). Similarly, verifying that a function called from the `render_block` hook runs only once (rather than repeatedly) for nested blocks isn't really unit test material.

---

Arguably, this PR fixes https://github.com/WordPress/block-interactivity-experiments/issues/148.