### PR TITLE
Add preact/debug tools to development version of bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {
-		"build": "webpack --mode=production",
-		"start": "webpack --mode=development --watch",
+		"build": "webpack",
+		"start": "webpack --watch",
 		"dev": "npm start",
 		"format:php": "wp-env run composer run-script format",
 		"lint:php": "wp-env run composer run-script lint",

--- a/src/runtime/debug.js
+++ b/src/runtime/debug.js
@@ -1,0 +1,2 @@
+// Must be the first import
+import 'preact/debug';

--- a/src/runtime/index.js
+++ b/src/runtime/index.js
@@ -1,3 +1,6 @@
+if (INCLUDE_DEBUG_TOOLS) {
+	require('./debug');
+}
 import registerDirectives from './directives';
 import registerComponents from './components';
 import { init } from './router';

--- a/src/runtime/index.js
+++ b/src/runtime/index.js
@@ -1,4 +1,4 @@
-if (INCLUDE_DEBUG_TOOLS) {
+if (SCRIPT_DEBUG) {
 	require('./debug');
 }
 import registerDirectives from './directives';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,7 +77,7 @@ module.exports = [
 		plugins: [
 			...sharedConfig.plugins,
 			new DefinePlugin({
-				INCLUDE_DEBUG_TOOLS: false,
+				SCRIPT_DEBUG: false,
 			}),
 		],
 	},
@@ -89,7 +89,7 @@ module.exports = [
 		plugins: [
 			...sharedConfig.plugins,
 			new DefinePlugin({
-				INCLUDE_DEBUG_TOOLS: true,
+				SCRIPT_DEBUG: true,
 			}),
 		],
 	},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,72 +1,104 @@
 const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+const { DefinePlugin } = require('webpack');
 const { resolve } = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+const sharedConfig = {
+	...defaultConfig,
+	output: {
+		filename: '[name].js',
+		path: resolve(process.cwd(), 'build'),
+		library: {
+			name: '__experimentalInteractivity',
+			type: 'window',
+		},
+	},
+	optimization: {
+		runtimeChunk: {
+			name: 'vendors',
+		},
+		splitChunks: {
+			cacheGroups: {
+				vendors: {
+					test: /[\\/]node_modules[\\/]/,
+					name: 'vendors',
+					minSize: 0,
+					chunks: 'all',
+				},
+			},
+		},
+	},
+	module: {
+		rules: [
+			{
+				test: /\.(j|t)sx?$/,
+				exclude: /node_modules/,
+				use: [
+					{
+						loader: require.resolve('babel-loader'),
+						options: {
+							cacheDirectory:
+								process.env.BABEL_CACHE_DIRECTORY || true,
+							babelrc: false,
+							configFile: false,
+							presets: [
+								[
+									'@babel/preset-react',
+									{
+										runtime: 'automatic',
+										importSource: 'preact',
+									},
+								],
+							],
+						},
+					},
+				],
+			},
+			{
+				test: /\.css$/i,
+				use: [MiniCssExtractPlugin.loader, 'css-loader'],
+			},
+		],
+	},
+	plugins: [new MiniCssExtractPlugin()],
+};
 
 module.exports = [
 	defaultConfig,
 	{
-		...defaultConfig,
+		...sharedConfig,
 		entry: {
 			runtime: './src/runtime',
+		},
+		output: {
+			...sharedConfig.output,
+			filename: '[name].min.js',
+		},
+		plugins: [
+			...sharedConfig.plugins,
+			new DefinePlugin({
+				INCLUDE_DEBUG_TOOLS: false,
+			}),
+		],
+	},
+	{
+		...sharedConfig,
+		entry: {
+			runtime: './src/runtime',
+		},
+		plugins: [
+			...sharedConfig.plugins,
+			new DefinePlugin({
+				INCLUDE_DEBUG_TOOLS: true,
+			}),
+		],
+	},
+	{
+		...sharedConfig,
+		entry: {
 			'e2e/page-1': './e2e/page-1',
 			'e2e/page-2': './e2e/page-2',
 			'e2e/html/directive-bind': './e2e/html/directive-bind',
 		},
-		output: {
-			filename: '[name].js',
-			path: resolve(process.cwd(), 'build'),
-			library: {
-				name: '__experimentalInteractivity',
-				type: 'window',
-			},
-		},
-		optimization: {
-			runtimeChunk: {
-				name: 'vendors',
-			},
-			splitChunks: {
-				cacheGroups: {
-					vendors: {
-						test: /[\\/]node_modules[\\/]/,
-						name: 'vendors',
-						minSize: 0,
-						chunks: 'all',
-					},
-				},
-			},
-		},
-		module: {
-			rules: [
-				{
-					test: /\.(j|t)sx?$/,
-					exclude: /node_modules/,
-					use: [
-						{
-							loader: require.resolve('babel-loader'),
-							options: {
-								cacheDirectory:
-									process.env.BABEL_CACHE_DIRECTORY || true,
-								babelrc: false,
-								configFile: false,
-								presets: [
-									[
-										'@babel/preset-react',
-										{
-											runtime: 'automatic',
-											importSource: 'preact',
-										},
-									],
-								],
-							},
-						},
-					],
-				},
-				{
-					test: /\.css$/i,
-					use: [MiniCssExtractPlugin.loader, 'css-loader'],
-				},
-			],
-		},
-		plugins: [new MiniCssExtractPlugin()],
 	},
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,9 +67,11 @@ module.exports = [
 	defaultConfig,
 	{
 		...sharedConfig,
+		name: 'runtime',
 		entry: {
 			runtime: './src/runtime',
 		},
+		mode: 'production',
 		output: {
 			...sharedConfig.output,
 			filename: '[name].min.js',
@@ -83,9 +85,11 @@ module.exports = [
 	},
 	{
 		...sharedConfig,
+		name: 'runtime-debug',
 		entry: {
 			runtime: './src/runtime',
 		},
+		mode: 'development',
 		plugins: [
 			...sharedConfig.plugins,
 			new DefinePlugin({
@@ -95,6 +99,8 @@ module.exports = [
 	},
 	{
 		...sharedConfig,
+		name: 'e2e',
+		mode: 'development',
 		entry: {
 			'e2e/page-1': './e2e/page-1',
 			'e2e/page-2': './e2e/page-2',

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -84,6 +84,8 @@ register_uninstall_hook( __FILE__, 'wp_directives_uninstall' );
  * Register the scripts
  */
 function wp_directives_register_scripts() {
+	$extension = SCRIPT_DEBUG ? '.js' : '.min.js';
+
 	wp_register_script(
 		'wp-directive-vendors',
 		plugins_url( 'build/vendors.js', __FILE__ ),
@@ -93,7 +95,7 @@ function wp_directives_register_scripts() {
 	);
 	wp_register_script(
 		'wp-directive-runtime',
-		plugins_url( 'build/runtime.js', __FILE__ ),
+		plugins_url( 'build/runtime' . $extension, __FILE__ ),
 		array( 'wp-directive-vendors' ),
 		'1.0.0',
 		true

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -88,7 +88,7 @@ function wp_directives_register_scripts() {
 
 	wp_register_script(
 		'wp-directive-vendors',
-		plugins_url( 'build/vendors.js', __FILE__ ),
+		plugins_url( 'build/vendors' . $extension, __FILE__ ),
 		array(),
 		'1.0.0',
 		true


### PR DESCRIPTION
See discussion #219 

This PR adds the preact debug tools to the runtime. Webpack now creates two versions of the runtime. A `runtime.js` including the debugtools and a `runtime.min.js` without them. Bundle size is nearly the same.

If `SCRIPT_DEBUG` is set to true, the plugin enqueues the version with debug tools. Both versions are minified. 
To make it work I had to extend the webpack config and return multiple configs - that's why common config is stored in a shared config. Also the `DefinePlugin` is used to build a constant which can be checked in the runtime on whether to import the debug tools or note. `preact/debug` cannot be externalized and needs to be the first import, that's why a flag is used.

I'm not a webpack expert, so if there's a better way to do it let me know. 

**How to test:**
1. Install the [preact devtools](https://preactjs.github.io/preact-devtools/)
2. Run `npm build` 
3. In `.wp-env.json` set `config`.`SCRIPT_DEBUG` to `true`
4. Start the local dev environment via `wp-env start`.
5. Enable "Client side navigation" in the plugins settings
6. Load the frontpage and check that `runtime.js` was loaded. Preact devtools should be enabled (and not show a warning about missing renderings). Preact devtools should show some directives.
7. In `.wp-env.json` set `config`.`SCRIPT_DEBUG` to `false`
8. 4. Start the local dev environment via `wp-env start`.
9. Load the frontpage and check that `runtime.min.js` was loaded. Preact devtools should not be enabled/active or show a warning about missing renderings.
10. All other things should work as expected (eg client side navigation).