### PR TITLE
Fix `evaluate` so it is always the same function instance

### DIFF
--- a/src/runtime/hooks.js
+++ b/src/runtime/hooks.js
@@ -1,5 +1,5 @@
 import { h, options, createContext } from 'preact';
-import { useRef } from 'preact/hooks';
+import { useRef, useMemo } from 'preact/hooks';
 import { rawStore as store } from './store';
 
 // Main context.
@@ -27,8 +27,8 @@ const getEvaluate =
 		const value = resolve(path, extraArgs.context);
 		return typeof value === 'function'
 			? value({
+					ref: ref.current,
 					...store,
-					...(ref !== undefined ? { ref } : {}),
 					...extraArgs,
 			  })
 			: value;
@@ -39,7 +39,7 @@ const Directive = ({ type, directives, props: originalProps }) => {
 	const ref = useRef(null);
 	const element = h(type, { ...originalProps, ref });
 	const props = { ...originalProps, children: element };
-	const evaluate = getEvaluate({ ref: ref.current });
+	const evaluate = useMemo(() => getEvaluate({ ref }), []);
 	const directiveArgs = { directives, props, element, context, evaluate };
 
 	for (const d in directives) {


### PR DESCRIPTION
The `evaluate` function that directives receive was generated by passing the `ref.current` value to `getEvaluate`, instead of `ref` directly. That forced the `Directive` wrapper to generate a new instance of `evaluate` each time `ref.current` changed, a new instance not referenced [here](https://github.com/WordPress/block-interactivity-experiments/blob/efcfa2a038be88ed5a97acdf668b5047a719ad77/src/runtime/directives.js#L51) in `wp-effect`.

This PR fixes that.

Related: https://github.com/WordPress/block-interactivity-experiments/issues/191