### PR TITLE
SSR: Don't process directives in inner blocks

### DIFF
--- a/wp-directives.php
+++ b/wp-directives.php
@@ -233,28 +233,39 @@ add_filter( 'render_block', 'wp_directives_mark_interactive_blocks', 10, 3 );
  */
 function wp_directives_inner_blocks( $parsed_block, $source_block, $parent_block ) {
 	if (
-		isset( $parent_block ) &&
-		block_has_support(
-			$parent_block->block_type,
-			array(
-				'interactivity',
-				'isolated',
-			)
-		)
+		isset( $parent_block )
 	) {
-		$parsed_block['isolated'] = true;
+		if (
+			block_has_support(
+				$parent_block->block_type,
+				array(
+					'interactivity',
+					'isolated',
+				)
+			)
+		) {
+			$parsed_block['isolated'] = true;
+		}
+		$parsed_block['inner_block'] = true;
 	}
 	return $parsed_block;
 }
 add_filter( 'render_block_data', 'wp_directives_inner_blocks', 10, 3 );
 
+
 /**
  * Process directives in block.
  *
- * @param string $block_content Block content.
+ * @param string   $block_content Block content.
+ * @param array    $block Block.
+ * @param WP_Block $instance Block instance.
  * @return string Filtered block content.
  */
-function process_directives_in_block( $block_content ) {
+function process_directives_in_block( $block_content, $block, $instance ) {
+	if ( isset( $instance->parsed_block['inner_block'] ) ) {
+		return $block_content;
+	}
+
 	// TODO: Add some directive/components registration mechanism.
 	$directives = array(
 		'data-wp-context' => 'process_wp_context',
@@ -273,7 +284,7 @@ add_filter(
 	'render_block',
 	'process_directives_in_block',
 	10,
-	1
+	3
 );
 
 // TODO: check if priority 9 is enough.


### PR DESCRIPTION
_Extracted from #215. See https://github.com/WordPress/block-interactivity-experiments/pull/215#issuecomment-1519743685 for the rationale._

Since we are [hooking `wp_process_directives` into `render_block`](https://github.com/WordPress/block-interactivity-experiments/blob/00f7825934ec58ed6482c2a7548f73a27d65f838/wp-directives.php#L251-L277), it gets run repeatedly on markup inside nested inner blocks (once for each level of block nesting around a given piece of markup).