### PR TITLE
Support enumerated attributes that can contain true or false

### DIFF
--- a/e2e/html/directive-bind.html
+++ b/e2e/html/directive-bind.html
@@ -45,6 +45,16 @@
 			Update
 		</button>
 
+		<p
+			data-wp-bind.hidden="!state.show"
+			data-wp-bind.aria-hidden="!state.show"
+			data-wp-bind.aria-expanded="state.show"
+			data-wp-bind.draggable="state.show"
+			data-testid="check enumerated attributes with true/false exist and have a string value"
+		>
+			Some Text
+		</p>
+
 		<script defer src="../../build/e2e/directive-bind.js"></script>
 		<script defer src="../../build/runtime.js"></script>
 		<script defer src="../../build/vendors.js"></script>

--- a/e2e/js/directive-bind.js
+++ b/e2e/js/directive-bind.js
@@ -4,6 +4,7 @@ store({
 	state: {
 		url: '/some-url',
 		checked: true,
+		show: false,
 		width: 1,
 	},
 	foo: {
@@ -13,6 +14,7 @@ store({
 		toggle: ({ state, foo }) => {
 			state.url = '/some-other-url';
 			state.checked = !state.checked;
+			state.show = !state.show;
 			state.width += foo.bar;
 		},
 	},

--- a/e2e/specs/directive-bind.spec.ts
+++ b/e2e/specs/directive-bind.spec.ts
@@ -63,4 +63,21 @@ test.describe('data-wp-bind', () => {
 		await expect(el).toHaveAttribute('href', '/some-other-url');
 		await expect(el2).toHaveAttribute('width', '2');
 	});
+
+	test('check enumerated attributes with true/false values', async ({
+		page,
+	}) => {
+		const el = page.getByTestId(
+			'check enumerated attributes with true/false exist and have a string value'
+		);
+		await expect(el).toHaveAttribute('hidden', '');
+		await expect(el).toHaveAttribute('aria-hidden', 'true');
+		await expect(el).toHaveAttribute('aria-expanded', 'false');
+		await expect(el).toHaveAttribute('draggable', 'false');
+		await page.getByTestId('toggle').click();
+		await expect(el).not.toHaveAttribute('hidden', '');
+		await expect(el).toHaveAttribute('aria-hidden', 'false');
+		await expect(el).toHaveAttribute('aria-expanded', 'true');
+		await expect(el).toHaveAttribute('draggable', 'true');
+	});
 });

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -120,7 +120,17 @@ export default () => {
 						// This seems necessary because Preact doesn't change the attributes
 						// on the hydration, so we have to do it manually. It doesn't need
 						// deps because it only needs to do it the first time.
-						if (result === false) {
+						if (
+							// Enumerated attributes that can contain `"true"` and/or `"false"`.
+							attribute.startsWith('aria-') ||
+							[
+								'contenteditable',
+								'draggable',
+								'spellcheck',
+							].includes(attribute)
+						) {
+							element.ref.current.setAttribute(attribute, result);
+						} else if (result === false) {
 							element.ref.current.removeAttribute(attribute);
 						} else {
 							element.ref.current.setAttribute(


### PR DESCRIPTION
In the `data-wp-bind` directive we are assuming that, when the value returns `true/false` it should be a [boolean attribute](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML). However, there are some [enumerated attributes](https://developer.mozilla.org/en-US/docs/Glossary/Enumerated) that can contain true or false as well (mainly the[ aria attributes](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/ARIA)):

* Boolean attributes: It is true when it is present, and false when it is absent.
* Enumerated attributes: Booleans only come in the form of strings "true" and "false".

For example, if we compare the `hidden` attribute (boolean), with the `aria-hidden` attribute (enumerated):

```html
<div hidden aria-hidden="true">Hidden element</div>
<div aria-hidden="false">Not hidden element</div>
```

At this moment, we are handling everything as boolean attributes, and this pull request aims to fix that.