### PR TITLE
Add priorities to directives

### DIFF
--- a/e2e/html/directive-priorities.html
+++ b/e2e/html/directive-priorities.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Directive priorities</title>
+		<meta itemprop="wp-client-side-navigation" content="active" />
+	</head>
+	<body>
+		<pre data-testid="execution order"></pre>
+
+		<!-- Element with test directives -->
+		<div
+			data-testid="test directives"
+			data-wp-test-attribute
+			data-wp-test-children
+			data-wp-test-text
+			data-wp-test-context
+		></div>
+
+		<script defer src="../../build/e2e/directive-priorities.js"></script>
+		<script defer src="../../build/runtime.js"></script>
+		<script defer src="../../build/vendors.js"></script>
+	</body>
+</html>

--- a/e2e/html/directives-context.html
+++ b/e2e/html/directives-context.html
@@ -105,6 +105,17 @@
 					obj.prop6
 				</button>
 			</div>
+			<br />
+
+			<button
+				data-testid="context & other directives"
+				data-wp-context='{ "text": "Text 1" }'
+				data-wp-text="context.text"
+				data-wp-on.click="actions.toggleContextText"
+				data-wp-bind.value="context.text"
+			>
+				Toggle Context Text
+			</button>
 		</div>
 
 		<script defer src="../../build/e2e/page-1.js"></script>

--- a/e2e/js/directive-priorities.js
+++ b/e2e/js/directive-priorities.js
@@ -1,0 +1,104 @@
+import { useEffect, useContext } from 'preact/hooks';
+import { deepSignal } from 'deepsignal';
+
+import { store } from '../../src/runtime/store';
+import { directive } from '../../src/runtime/hooks';
+
+/**
+ * Util to check that render calls happen in order.
+ */
+const executionProof = (n) => {
+	const el = document.querySelector('[data-testid="execution order"]');
+	if (!el.textContent) el.textContent = n;
+	else el.textContent += `, ${n}`;
+};
+
+/**
+ * Simple context directive, just for testing purposes. It provides a deep
+ * signal with these two properties:
+ * - attribute: 'from context'
+ * - text: 'from context'
+ */
+directive(
+	'test-context',
+	({ context: { Provider }, props: { children } }) => {
+		executionProof('context');
+		const value = deepSignal({
+			attribute: 'from context',
+			text: 'from context',
+		});
+		return <Provider value={value}>{children}</Provider>;
+	},
+	{ priority: 8 }
+);
+
+/**
+ * Simple attribute directive, for testing purposes. It reads the value of
+ * `attribute` from context and populates `data-attribute` with it.
+ */
+directive('test-attribute', ({ context, evaluate, element }) => {
+	executionProof('attribute');
+	const contextValue = useContext(context);
+	const attributeValue = evaluate('context.attribute', {
+		context: contextValue,
+	});
+	useEffect(() => {
+		element.ref.current.setAttribute('data-attribute', attributeValue);
+	}, []);
+	element.props['data-attribute'] = attributeValue;
+});
+
+/**
+ * Simple text directive, for testing purposes. It reads the value of
+ * `text` from context and populates `children` with it.
+ */
+directive(
+	'test-text',
+	({ context, evaluate, element }) => {
+		executionProof('text');
+		const contextValue = useContext(context);
+		const textValue = evaluate('context.text', {
+			context: contextValue,
+		});
+		element.props.children = <p data-testid="text">{textValue}</p>;
+	},
+	{ priority: 12 }
+);
+
+/**
+ * Children directive, for testing purposes. It adds a wrapper around
+ * `children`, including two buttons to modify `text` and `attribute values from
+ * the received context.
+ */
+directive(
+	'test-children',
+	({ context, evaluate, element }) => {
+		executionProof('children');
+		const contextValue = useContext(context);
+		const updateAttribute = () => {
+			evaluate('actions.updateAttribute', { context: contextValue });
+		};
+		const updateText = () => {
+			evaluate('actions.updateText', { context: contextValue });
+		};
+		element.props.children = (
+			<div>
+				{element.props.children}
+				<button onClick={updateAttribute}>Update attribute</button>
+				<button onClick={updateText}>Update text</button>
+			</div>
+		);
+	},
+	{ priority: 14 }
+);
+
+store({
+	actions: {
+		updateText({ context }) {
+			context.text = 'updated';
+		},
+		updateAttribute({ context }) {
+			context.attribute = 'updated';
+		},
+	},
+});

--- a/e2e/js/directive-priorities.js
+++ b/e2e/js/directive-priorities.js
@@ -67,8 +67,8 @@ directive(
 
 /**
  * Children directive, for testing purposes. It adds a wrapper around
- * `children`, including two buttons to modify `text` and `attribute values from
- * the received context.
+ * `children`, including two buttons to modify `text` and `attribute` values
+ * from the received context.
  */
 directive(
 	'test-children',

--- a/e2e/specs/directive-priorities.spec.ts
+++ b/e2e/specs/directive-priorities.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '../tests';
+
+test.describe('Directives (w/ priority)', () => {
+	test.beforeEach(async ({ goToFile }) => {
+		await goToFile('directive-priorities.html');
+	});
+
+	test('should run in priority order', async ({ page }) => {
+		const executionOrder = page.getByTestId('execution order');
+		await expect(executionOrder).toHaveText(
+			'context, attribute, text, children'
+		);
+	});
+
+	test('should wrap those with less priority', async ({ page }) => {
+		// Check that attribute value is correctly received from Provider.
+		const element = page.getByTestId('test directives');
+		await expect(element).toHaveAttribute('data-attribute', 'from context');
+
+		// Check that text value is correctly received from Provider, and text
+		// wrapped with an element with `data-testid=text`.
+		const text = element.getByTestId('text');
+		await expect(text).toHaveText('from context');
+	});
+
+	test('should propagate element modifications top-down', async ({
+		page,
+	}) => {
+		const executionOrder = page.getByTestId('execution order');
+		const element = page.getByTestId('test directives');
+		const text = element.getByTestId('text');
+
+		// Get buttons.
+		const updateAttribute = element.getByRole('button', {
+			name: 'Update attribute',
+		});
+		const updateText = element.getByRole('button', {
+			name: 'Update text',
+		});
+
+		// Modify `attribute` inside context. This triggers a re-render for the
+		// component that wraps the `attribute` directive, evaluating it again.
+		// Nested components are re-rendered as well, so their directives are
+		// also re-evaluated (note how `text` and `children` have run).
+		await updateAttribute.click();
+		await expect(element).toHaveAttribute('data-attribute', 'updated');
+		await expect(executionOrder).toHaveText(
+			[
+				'context, attribute, text, children',
+				'attribute, text, children',
+			].join(', ')
+		);
+
+		// Modify `text` inside context. This triggers a re-render of the
+		// component that wraps the `text` directive. In this case, only
+		// `children` run as well, right after `text`.
+		await updateText.click();
+		await expect(element).toHaveAttribute('data-attribute', 'updated');
+		await expect(text).toHaveText('updated');
+		await expect(executionOrder).toHaveText(
+			[
+				'context, attribute, text, children',
+				'attribute, text, children',
+				'text, children',
+			].join(', ')
+		);
+	});
+});

--- a/e2e/specs/directives-context.spec.ts
+++ b/e2e/specs/directives-context.spec.ts
@@ -132,4 +132,19 @@ test.describe('data-wp-context', () => {
 		expect(parentContext.array).toMatchObject([1, 2, 3]);
 		expect(childContext.array).toMatchObject([4, 5, 6]);
 	});
+
+	test('can be accessed in other directives on the same element', async ({
+		page,
+	}) => {
+		await page.pause();
+		const element = page.getByTestId('context & other directives');
+		await expect(element).toHaveText('Text 1');
+		await expect(element).toHaveAttribute('value', 'Text 1');
+		await element.click();
+		await expect(element).toHaveText('Text 2');
+		await expect(element).toHaveAttribute('value', 'Text 2');
+		await element.click();
+		await expect(element).toHaveText('Text 1');
+		await expect(element).toHaveAttribute('value', 'Text 1');
+	});
 });

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -40,7 +40,8 @@ export default () => {
 			}, [context, inheritedValue]);
 
 			return <Provider value={value}>{children}</Provider>;
-		}
+		},
+		{ priority: 5 }
 	);
 
 	// data-wp-effect.[name]

--- a/src/runtime/hooks.js
+++ b/src/runtime/hooks.js
@@ -82,17 +82,18 @@ const RecursivePriorityLevel = ({
 	originalProps,
 }) => {
 	// This element needs to be a fresh copy so we are not modifying an already
-	// rendered element. This prevents an error with changes in
-	// `element.props.children` not being reflected in `element.__k`.
+	// rendered element with Preact's internal properties initialized. This
+	// prevents an error with changes in `element.props.children` not being
+	// reflected in `element.__k`.
 	element = cloneElement(element);
 
 	// Recursively render the wrapper for the next priority level.
 	//
-	// Note that, even though we're effectively calling `createElement` here,
-	// the element will not be rendered just yet. In fact, the render function
-	// of `RecursivePriorityLevel` will be delayed until the current render
-	// function has finished. That ensures directives in the current priorty
-	// level have run (and thus modified `element`) before the next level.
+	// Note that, even though we're instantiating a vnode with a
+	// `RecursivePriorityLevel` here, its render function will not be executed
+	// just yet. Actually, it will be delayed until the current render function
+	// has finished. That ensures directives in the current priorty level have
+	// run (and thus modified the passed `element`) before the next level.
 	const children =
 		rest.length > 0 ? (
 			<RecursivePriorityLevel

--- a/src/runtime/hooks.js
+++ b/src/runtime/hooks.js
@@ -1,4 +1,4 @@
-import { h, options, createContext } from 'preact';
+import { h, options, createContext, cloneElement } from 'preact';
 import { useRef, useMemo } from 'preact/hooks';
 import { rawStore as store } from './store';
 
@@ -62,7 +62,7 @@ const usePriorityLevels = (directives) =>
 // Directive wrapper.
 const Directive = ({ type, directives, props: originalProps }) => {
 	const ref = useRef(null);
-	const element = useMemo(() => h(type, { ...originalProps, ref }), []);
+	const element = h(type, { ...originalProps, ref });
 	const evaluate = useMemo(() => getEvaluate({ ref }), []);
 
 	// Add wrappers recursively for each priority level.
@@ -73,21 +73,19 @@ const Directive = ({ type, directives, props: originalProps }) => {
 			element={element}
 			evaluate={evaluate}
 			originalProps={originalProps}
-		>
-			{element}
-		</RecursivePriorityLevel>
+		/>
 	);
 };
 
 // Priority level wrapper.
 const RecursivePriorityLevel = ({
 	directives: [directives, ...rest],
-	element,
+	element: passedElement,
 	evaluate,
 	originalProps,
-	children,
 }) => {
-	const props = { ...originalProps, children };
+	const element = cloneElement(passedElement);
+	const props = { ...originalProps, children: element };
 	const directiveArgs = { directives, props, element, context, evaluate };
 
 	for (const d in directives) {
@@ -105,9 +103,7 @@ const RecursivePriorityLevel = ({
 			element={element}
 			evaluate={evaluate}
 			originalProps={originalProps}
-		>
-			{props.children}
-		</RecursivePriorityLevel>
+		/>
 	);
 };
 

--- a/src/runtime/hooks.js
+++ b/src/runtime/hooks.js
@@ -84,8 +84,18 @@ const RecursivePriorityLevel = ({
 	evaluate,
 	originalProps,
 }) => {
+	// This element needs to be a fresh copy so we are not modifying an already
+	// rendered element. This prevents an error with changes in
+	// `element.props.children` not being reflected in `element.__k`.
 	element = cloneElement(element);
 
+	// Recursively render the wrapper for the next priority level.
+	//
+	// Note that, even though we're effectively calling `createElement` here,
+	// the element will not be rendered just yet. In fact, the render function
+	// of `RecursivePriorityLevel` will be delayed until the current render
+	// function has finished. That ensures directives in the current priorty
+	// level have run (and thus modified `element`) before the next level.
 	const children =
 		rest.length > 0 ? (
 			<RecursivePriorityLevel

--- a/src/runtime/hooks.js
+++ b/src/runtime/hooks.js
@@ -80,12 +80,25 @@ const Directive = ({ type, directives, props: originalProps }) => {
 // Priority level wrapper.
 const RecursivePriorityLevel = ({
 	directives: [directives, ...rest],
-	element: passedElement,
+	element,
 	evaluate,
 	originalProps,
 }) => {
-	const element = cloneElement(passedElement);
-	const props = { ...originalProps, children: element };
+	element = cloneElement(element);
+
+	const children =
+		rest.length > 0 ? (
+			<RecursivePriorityLevel
+				directives={rest}
+				element={element}
+				evaluate={evaluate}
+				originalProps={originalProps}
+			/>
+		) : (
+			element
+		);
+
+	const props = { ...originalProps, children };
 	const directiveArgs = { directives, props, element, context, evaluate };
 
 	for (const d in directives) {
@@ -93,18 +106,7 @@ const RecursivePriorityLevel = ({
 		if (wrapper !== undefined) props.children = wrapper;
 	}
 
-	if (rest.length === 0) {
-		return props.children;
-	}
-
-	return (
-		<RecursivePriorityLevel
-			directives={rest}
-			element={element}
-			evaluate={evaluate}
-			originalProps={originalProps}
-		/>
-	);
+	return props.children;
 };
 
 // Preact Options Hook called each time a vnode is created.

--- a/src/runtime/hooks.js
+++ b/src/runtime/hooks.js
@@ -43,11 +43,8 @@ const usePriorityLevels = (directives) =>
 		const byPriority = Object.entries(directives).reduce(
 			(acc, [name, values]) => {
 				const priority = directivePriorities[name];
-				if (!acc[priority]) {
-					acc[priority] = { [name]: values };
-				} else {
-					acc[priority][name] = values;
-				}
+				if (!acc[priority]) acc[priority] = {};
+				acc[priority][name] = values;
 
 				return acc;
 			},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = [
 			runtime: './src/runtime',
 			'e2e/page-1': './e2e/page-1',
 			'e2e/page-2': './e2e/page-2',
+			'e2e/directive-priorities': './e2e/js/directive-priorities',
 			'e2e/directive-bind': './e2e/js/directive-bind',
 			'e2e/directive-effect': './e2e/js/directive-effect',
 		},


### PR DESCRIPTION
## What

This PR extends the `directive()` function API to add a new option called `priority`, making directives **on the same element** to be evaluated in priority order. In such an element, directives with the same priority are evaluated together, wrapped in the same component, and those with less priority are wrapped in a nested component.

Priorities follow the same schema as in WordPress, i.e., priority is a numeric value, lower numbers correspond with earlier execution ("more" priority), and the default value is `10`.

Note that this value is per directive type, as it is set during directive definition. It doesn't allow changing the order in which directives are evaluated on different parts of the HTML.

A trivial example:

```js
directive(
  'customdirective',
  ({ directives: { customdirective }) => { /* ... */ },
  { priority: 12 } // arbitrary value, just for display purposes
);
```

In addition, the priority for the `data-wp-context` directive has been set to `5`.

## Why

Priorities allow directives to manipulate the element in which they appear, in the correct order. It is especially convenient for directives that add wrappers, like a context `Provider` (e.g. `data-wp-context`), allowing other directives with less priority in the same element to consume that context.

## How

The main changes are in `/src/runtime/hooks.js`:
- I've implemented a hook called `usePriorityLevels`, that receives the object with all directives defined in an element and returns them sorted and grouped by priority.
- I'm using a recursive component called `RecursivePriorityLevel` inside the `Directive` component. It renders a component instance for each priority level that `usePriorityLevels` yields.