### PR TITLE
Follow preact logic on enumerated attributes

### DIFF
--- a/e2e/html/directive-bind.html
+++ b/e2e/html/directive-bind.html
@@ -49,7 +49,7 @@
 			data-wp-bind.hidden="!state.show"
 			data-wp-bind.aria-hidden="!state.show"
 			data-wp-bind.aria-expanded="state.show"
-			data-wp-bind.draggable="state.show"
+			data-wp-bind.data-some-value="state.show"
 			data-testid="check enumerated attributes with true/false exist and have a string value"
 		>
 			Some Text

--- a/e2e/specs/directive-bind.spec.ts
+++ b/e2e/specs/directive-bind.spec.ts
@@ -73,11 +73,11 @@ test.describe('data-wp-bind', () => {
 		await expect(el).toHaveAttribute('hidden', '');
 		await expect(el).toHaveAttribute('aria-hidden', 'true');
 		await expect(el).toHaveAttribute('aria-expanded', 'false');
-		await expect(el).toHaveAttribute('draggable', 'false');
+		await expect(el).toHaveAttribute('data-some-value', 'false');
 		await page.getByTestId('toggle').click();
 		await expect(el).not.toHaveAttribute('hidden', '');
 		await expect(el).toHaveAttribute('aria-hidden', 'false');
 		await expect(el).toHaveAttribute('aria-expanded', 'true');
-		await expect(el).toHaveAttribute('draggable', 'true');
+		await expect(el).toHaveAttribute('data-some-value', 'true');
 	});
 });

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -120,21 +120,18 @@ export default () => {
 					// on the hydration, so we have to do it manually. It doesn't need
 					// deps because it only needs to do it the first time.
 					useEffect(() => {
-						if (
-							// aria- and data- attributes have no boolean representation.
-							// A `false` value is different from the attribute not being
-							// present, so we can't remove it.
-							//
-							// We follow Preact's logic: https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L131C24-L136
-							attribute[4] === '-'
-						) {
-							element.ref.current.setAttribute(attribute, result);
-						} else if (result === false) {
+						// aria- and data- attributes have no boolean representation.
+						// A `false` value is different from the attribute not being
+						// present, so we can't remove it.
+						// We follow Preact's logic: https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L131C24-L136
+						if (result === false && attribute[4] !== '-') {
 							element.ref.current.removeAttribute(attribute);
 						} else {
 							element.ref.current.setAttribute(
 								attribute,
-								result === true ? '' : result
+								result === true && attribute[4] !== '-'
+									? ''
+									: result
 							);
 						}
 					}, []);

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -116,18 +116,17 @@ export default () => {
 					});
 					element.props[attribute] = result;
 
+					// This seems necessary because Preact doesn't change the attributes
+					// on the hydration, so we have to do it manually. It doesn't need
+					// deps because it only needs to do it the first time.
 					useEffect(() => {
-						// This seems necessary because Preact doesn't change the attributes
-						// on the hydration, so we have to do it manually. It doesn't need
-						// deps because it only needs to do it the first time.
 						if (
-							// Enumerated attributes that can contain `"true"` and/or `"false"`.
-							attribute.startsWith('aria-') ||
-							[
-								'contenteditable',
-								'draggable',
-								'spellcheck',
-							].includes(attribute)
+							// aria- and data- attributes have no boolean representation.
+							// A `false` value is different from the attribute not being
+							// present, so we can't remove it.
+							//
+							// We follow Preact's logic: https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L131C24-L136
+							attribute[4] === '-'
 						) {
 							element.ref.current.setAttribute(attribute, result);
 						} else if (result === false) {


### PR DESCRIPTION
## What

I have replaced the logic of the enumerated attributes to match Preact's logic.

## Why

I was having second thoughts about including `contenteditable`, `draggable` and `spellcheck` in the codebase. If we do that, we'd need to add all the exceptions, when those cases can be handled by returning the `"true"` and `"false"` strings.

Also, whatever we do needs to match what Preact does to avoid inconsistencies.

## How

[This is Preact's logic](https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L131C24-L136), so just replace our logic with that one that only treats `aria-` and `data-` as special enumerated attributes.