### PR TITLE
Rename sufix character and island directive

### DIFF
--- a/e2e/html/csn-page-2.html
+++ b/e2e/html/csn-page-2.html
@@ -14,7 +14,7 @@
 		<h1 data-testid="csn-heading-page-2">Client-side navigation Page 2</h1>
 		<h2 data-testid="csn-subheading">Subheading</h2>
 		<button
-			data-wp-on.click="actions.toggleNewValue"
+			data-wp-on--click="actions.toggleNewValue"
 			data-testid="toggle newValue"
 		>
 			Toggle trueValue
@@ -29,7 +29,7 @@
 		</div>
 
 		<button
-			data-wp-on.click="actions.replaceWithPage3"
+			data-wp-on--click="actions.replaceWithPage3"
 			data-testid="replace with page 3"
 		>
 			Replace with page 3

--- a/e2e/html/directive-bind.html
+++ b/e2e/html/directive-bind.html
@@ -6,50 +6,50 @@
 	</head>
 	<body>
 		<a
-			data-wp-bind.href="state.url"
+			data-wp-bind--href="state.url"
 			data-testid="add missing href at hydration"
 		></a>
 
 		<a
 			href="/other-url"
-			data-wp-bind.href="state.url"
+			data-wp-bind--href="state.url"
 			data-testid="change href at hydration"
 		></a>
 
 		<input
 			type="checkbox"
-			data-wp-bind.checked="state.checked"
+			data-wp-bind--checked="state.checked"
 			data-testid="add missing checked at hydration"
 		/>
 
 		<input
 			type="checkbox"
 			checked
-			data-wp-bind.checked="!state.checked"
+			data-wp-bind--checked="!state.checked"
 			data-testid="remove existing checked at hydration"
 		/>
 
 		<a
 			href="/other-url"
-			data-wp-bind.href="state.url"
+			data-wp-bind--href="state.url"
 			data-testid="nested binds - 1"
 		>
 			<img
 				width="1"
-				data-wp-bind.width="state.width"
+				data-wp-bind--width="state.width"
 				data-testid="nested binds - 2"
 			/>
 		</a>
 
-		<button data-testid="toggle" data-wp-on.click="actions.toggle">
+		<button data-testid="toggle" data-wp-on--click="actions.toggle">
 			Update
 		</button>
 
 		<p
-			data-wp-bind.hidden="!state.show"
-			data-wp-bind.aria-hidden="!state.show"
-			data-wp-bind.aria-expanded="state.show"
-			data-wp-bind.data-some-value="state.show"
+			data-wp-bind--hidden="!state.show"
+			data-wp-bind--aria-hidden="!state.show"
+			data-wp-bind--aria-expanded="state.show"
+			data-wp-bind--data-some-value="state.show"
 			data-testid="check enumerated attributes with true/false exist and have a string value"
 		>
 			Some Text

--- a/e2e/html/directives-class.html
+++ b/e2e/html/directives-class.html
@@ -6,14 +6,14 @@
 	</head>
 	<body>
 		<button
-			data-wp-on.click="actions.toggleTrueValue"
+			data-wp-on--click="actions.toggleTrueValue"
 			data-testid="toggle trueValue"
 		>
 			Toggle trueValue
 		</button>
 
 		<button
-			data-wp-on.click="actions.toggleFalseValue"
+			data-wp-on--click="actions.toggleFalseValue"
 			data-testid="toggle falseValue"
 		>
 			Toggle falseValue
@@ -21,50 +21,50 @@
 
 		<div
 			class="foo bar"
-			data-wp-class.foo="state.falseValue"
+			data-wp-class--foo="state.falseValue"
 			data-testid="remove class if callback returns falsy value"
 		></div>
 
 		<div
 			class="foo"
-			data-wp-class.bar="state.trueValue"
+			data-wp-class--bar="state.trueValue"
 			data-testid="add class if callback returns truthy value"
 		></div>
 
 		<div
 			class="foo bar"
-			data-wp-class.foo="state.falseValue"
-			data-wp-class.bar="state.trueValue"
-			data-wp-class.baz="state.trueValue"
+			data-wp-class--foo="state.falseValue"
+			data-wp-class--bar="state.trueValue"
+			data-wp-class--baz="state.trueValue"
 			data-testid="handles multiple classes and callbacks"
 		></div>
 
 		<div
 			class="foo foo-bar"
-			data-wp-class.foo="state.falseValue"
-			data-wp-class.foo-bar="state.trueValue"
+			data-wp-class--foo="state.falseValue"
+			data-wp-class--foo-bar="state.trueValue"
 			data-testid="handles class names that are contained inside other class names"
 		></div>
 
 		<div
 			class="foo bar baz"
-			data-wp-class.bar="state.trueValue"
+			data-wp-class--bar="state.trueValue"
 			data-testid="can toggle class in the middle"
 		></div>
 
 		<div
-			data-wp-class.foo="state.falseValue"
+			data-wp-class--foo="state.falseValue"
 			data-testid="can toggle class when class attribute is missing"
 		></div>
 
 		<div data-wp-context='{ "falseValue": false }'>
 			<div
 				class="foo"
-				data-wp-class.foo="context.falseValue"
+				data-wp-class--foo="context.falseValue"
 				data-testid="can use context values"
 			></div>
 			<button
-				data-wp-on.click="actions.toggleContextFalseValue"
+				data-wp-on--click="actions.toggleContextFalseValue"
 				data-testid="toggle context false value"
 			>
 				Toggle context falseValue

--- a/e2e/html/directives-context.html
+++ b/e2e/html/directives-context.html
@@ -11,7 +11,7 @@
 		>
 			<pre
 				data-testid="parent context"
-				data-wp-bind.children="derived.renderContext"
+				data-wp-bind--children="derived.renderContext"
 			>
                 <!-- rendered during hydration -->
             </pre>
@@ -19,7 +19,7 @@
 				data-testid="parent prop1"
 				name="prop1"
 				value="modifiedFromParent"
-				data-wp-on.click="actions.updateContext"
+				data-wp-on--click="actions.updateContext"
 			>
 				prop1
 			</button>
@@ -27,7 +27,7 @@
 				data-testid="parent prop2"
 				name="prop2"
 				value="modifiedFromParent"
-				data-wp-on.click="actions.updateContext"
+				data-wp-on--click="actions.updateContext"
 			>
 				prop2
 			</button>
@@ -35,7 +35,7 @@
 				data-testid="parent obj.prop4"
 				name="obj.prop4"
 				value="modifiedFromParent"
-				data-wp-on.click="actions.updateContext"
+				data-wp-on--click="actions.updateContext"
 			>
 				obj.prop4
 			</button>
@@ -43,7 +43,7 @@
 				data-testid="parent obj.prop5"
 				name="obj.prop5"
 				value="modifiedFromParent"
-				data-wp-on.click="actions.updateContext"
+				data-wp-on--click="actions.updateContext"
 			>
 				obj.prop5
 			</button>
@@ -52,7 +52,7 @@
 			>
 				<pre
 					data-testid="child context"
-					data-wp-bind.children="derived.renderContext"
+					data-wp-bind--children="derived.renderContext"
 				>
                     <!-- rendered during hydration -->
                 </pre>
@@ -60,7 +60,7 @@
 					data-testid="child prop1"
 					name="prop1"
 					value="modifiedFromChild"
-					data-wp-on.click="actions.updateContext"
+					data-wp-on--click="actions.updateContext"
 				>
 					prop1
 				</button>
@@ -68,7 +68,7 @@
 					data-testid="child prop2"
 					name="prop2"
 					value="modifiedFromChild"
-					data-wp-on.click="actions.updateContext"
+					data-wp-on--click="actions.updateContext"
 				>
 					prop2
 				</button>
@@ -76,7 +76,7 @@
 					data-testid="child prop3"
 					name="prop3"
 					value="modifiedFromChild"
-					data-wp-on.click="actions.updateContext"
+					data-wp-on--click="actions.updateContext"
 				>
 					prop3
 				</button>
@@ -84,7 +84,7 @@
 					data-testid="child obj.prop4"
 					name="obj.prop4"
 					value="modifiedFromChild"
-					data-wp-on.click="actions.updateContext"
+					data-wp-on--click="actions.updateContext"
 				>
 					obj.prop4
 				</button>
@@ -92,7 +92,7 @@
 					data-testid="child obj.prop5"
 					name="obj.prop5"
 					value="modifiedFromChild"
-					data-wp-on.click="actions.updateContext"
+					data-wp-on--click="actions.updateContext"
 				>
 					obj.prop5
 				</button>
@@ -100,7 +100,7 @@
 					data-testid="child obj.prop6"
 					name="obj.prop6"
 					value="modifiedFromChild"
-					data-wp-on.click="actions.updateContext"
+					data-wp-on--click="actions.updateContext"
 				>
 					obj.prop6
 				</button>
@@ -111,8 +111,8 @@
 				data-testid="context & other directives"
 				data-wp-context='{ "text": "Text 1" }'
 				data-wp-text="context.text"
-				data-wp-on.click="actions.toggleContextText"
-				data-wp-bind.value="context.text"
+				data-wp-on--click="actions.toggleContextText"
+				data-wp-bind--value="context.text"
 			>
 				Toggle Context Text
 			</button>

--- a/e2e/html/directives-effect.html
+++ b/e2e/html/directives-effect.html
@@ -20,7 +20,7 @@
 
 		<div data-wp-effect="effects.changeFocus"></div>
 
-		<button data-testid="toggle" data-wp-on.click="actions.toggle">
+		<button data-testid="toggle" data-wp-on--click="actions.toggle">
 			Update
 		</button>
 

--- a/e2e/html/directives-show.html
+++ b/e2e/html/directives-show.html
@@ -6,14 +6,14 @@
 	</head>
 	<body>
 		<button
-			data-wp-on.click="actions.toggleTrueValue"
+			data-wp-on--click="actions.toggleTrueValue"
 			data-testid="toggle trueValue"
 		>
 			Toggle trueValue
 		</button>
 
 		<button
-			data-wp-on.click="actions.toggleFalseValue"
+			data-wp-on--click="actions.toggleFalseValue"
 			data-testid="toggle falseValue"
 		>
 			Toggle falseValue
@@ -42,7 +42,7 @@
 				falseValue
 			</div>
 			<button
-				data-wp-on.click="actions.toggleContextFalseValue"
+				data-wp-on--click="actions.toggleContextFalseValue"
 				data-testid="toggle context false value"
 			>
 				Toggle context falseValue

--- a/e2e/html/directives-text.html
+++ b/e2e/html/directives-text.html
@@ -11,7 +11,7 @@
 				data-testid="show state text"
 			></span>
 			<button
-				data-wp-on.click="actions.toggleStateText"
+				data-wp-on--click="actions.toggleStateText"
 				data-testid="toggle state text"
 			>
 				Toggle State Text
@@ -24,7 +24,7 @@
 				data-testid="show context text"
 			></span>
 			<button
-				data-wp-on.click="actions.toggleContextText"
+				data-wp-on--click="actions.toggleContextText"
 				data-testid="toggle context text"
 			>
 				Toggle Context Text

--- a/e2e/html/negation-operator.html
+++ b/e2e/html/negation-operator.html
@@ -6,19 +6,19 @@
 	</head>
 	<body>
 		<button
-			data-wp-on.click="actions.toggle"
+			data-wp-on--click="actions.toggle"
 			data-testid="toggle active value"
 		>
 			Toggle Active Value
 		</button>
 
 		<div
-			data-wp-bind.hidden="!state.active"
+			data-wp-bind--hidden="!state.active"
 			data-testid="add hidden attribute if state is not active"
 		></div>
 
 		<div
-			data-wp-bind.hidden="!selectors.active"
+			data-wp-bind--hidden="!selectors.active"
 			data-testid="add hidden attribute if selector is not active"
 		></div>
 

--- a/e2e/html/store-tag-corrupted-json.html
+++ b/e2e/html/store-tag-corrupted-json.html
@@ -9,26 +9,26 @@
 		<div>
 			Counter:
 			<span
-				data-wp-bind.children="state.counter.value"
+				data-wp-bind--children="state.counter.value"
 				data-testid="counter value"
 				>3</span
 			>
 			<br />
 			Double:
 			<span
-				data-wp-bind.children="state.counter.double"
+				data-wp-bind--children="state.counter.double"
 				data-testid="counter double"
 				>6</span
 			>
 			<br />
 			<button
-				data-wp-on.click="actions.counter.increment"
+				data-wp-on--click="actions.counter.increment"
 				data-testid="counter button"
 			>
 				+1
 			</button>
 			<span
-				data-wp-bind.children="state.counter.clicks"
+				data-wp-bind--children="state.counter.clicks"
 				data-testid="counter clicks"
 				>0</span
 			>

--- a/e2e/html/store-tag-invalid-state.html
+++ b/e2e/html/store-tag-invalid-state.html
@@ -9,26 +9,26 @@
 		<div>
 			Counter:
 			<span
-				data-wp-bind.children="state.counter.value"
+				data-wp-bind--children="state.counter.value"
 				data-testid="counter value"
 				>3</span
 			>
 			<br />
 			Double:
 			<span
-				data-wp-bind.children="state.counter.double"
+				data-wp-bind--children="state.counter.double"
 				data-testid="counter double"
 				>6</span
 			>
 			<br />
 			<button
-				data-wp-on.click="actions.counter.increment"
+				data-wp-on--click="actions.counter.increment"
 				data-testid="counter button"
 			>
 				+1
 			</button>
 			<span
-				data-wp-bind.children="state.counter.clicks"
+				data-wp-bind--children="state.counter.clicks"
 				data-testid="counter clicks"
 				>0</span
 			>

--- a/e2e/html/store-tag-missing.html
+++ b/e2e/html/store-tag-missing.html
@@ -9,26 +9,26 @@
 		<div>
 			Counter:
 			<span
-				data-wp-bind.children="state.counter.value"
+				data-wp-bind--children="state.counter.value"
 				data-testid="counter value"
 				>3</span
 			>
 			<br />
 			Double:
 			<span
-				data-wp-bind.children="state.counter.double"
+				data-wp-bind--children="state.counter.double"
 				data-testid="counter double"
 				>6</span
 			>
 			<br />
 			<button
-				data-wp-on.click="actions.counter.increment"
+				data-wp-on--click="actions.counter.increment"
 				data-testid="counter button"
 			>
 				+1
 			</button>
 			<span
-				data-wp-bind.children="state.counter.clicks"
+				data-wp-bind--children="state.counter.clicks"
 				data-testid="counter clicks"
 				>0</span
 			>

--- a/e2e/html/store-tag-ok.html
+++ b/e2e/html/store-tag-ok.html
@@ -9,26 +9,26 @@
 		<div>
 			Counter:
 			<span
-				data-wp-bind.children="state.counter.value"
+				data-wp-bind--children="state.counter.value"
 				data-testid="counter value"
 				>3</span
 			>
 			<br />
 			Double:
 			<span
-				data-wp-bind.children="state.counter.double"
+				data-wp-bind--children="state.counter.double"
 				data-testid="counter double"
 				>6</span
 			>
 			<br />
 			<button
-				data-wp-on.click="actions.counter.increment"
+				data-wp-on--click="actions.counter.increment"
 				data-testid="counter button"
 			>
 				+1
 			</button>
 			<span
-				data-wp-bind.children="state.counter.clicks"
+				data-wp-bind--children="state.counter.clicks"
 				data-testid="counter clicks"
 				>0</span
 			>

--- a/e2e/html/tovdom-islands.html
+++ b/e2e/html/tovdom-islands.html
@@ -11,7 +11,7 @@
 				</span>
 			</div>
 
-			<div data-wp-island>
+			<div data-wp-interactive>
 				<div data-wp-show="state.falseValue">
 					<span data-testid="inside an island">
 						This should not be shown because it is inside an island.
@@ -19,7 +19,7 @@
 				</div>
 			</div>
 
-			<div data-wp-island>
+			<div data-wp-interactive>
 				<div data-wp-ignore>
 					<div data-wp-show="state.falseValue">
 						<span
@@ -32,8 +32,8 @@
 				</div>
 			</div>
 
-			<div data-wp-island>
-				<div data-wp-island>
+			<div data-wp-interactive>
+				<div data-wp-interactive>
 					<div
 						data-wp-show="state.falseValue"
 						data-testid="island inside another island"
@@ -46,9 +46,9 @@
 				</div>
 			</div>
 
-			<div data-wp-island>
+			<div data-wp-interactive>
 				<div>
-					<div data-wp-island data-wp-ignore>
+					<div data-wp-interactive data-wp-ignore>
 						<div data-wp-show="state.falseValue">
 							<span
 								data-testid="island inside inner block of isolated island"

--- a/e2e/html/tovdom.html
+++ b/e2e/html/tovdom.html
@@ -4,7 +4,7 @@
 		<title>toVdom</title>
 	</head>
 
-	<body data-wp-island>
+	<body data-wp-interactive>
 		<div data-testid="it should delete comments">
 			<!-- ##1## -->
 			<div data-testid="it should keep this node between comments">

--- a/phpunit/directives/attributes/wp-bind.php
+++ b/phpunit/directives/attributes/wp-bind.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/../../../src/directives/wp-html.php';
  */
 class Tests_Directives_WpBind extends WP_UnitTestCase {
 	public function test_directive_sets_attribute() {
-		$markup = '<img data-wp-bind.src="context.myblock.imageSource" />';
+		$markup = '<img data-wp-bind--src="context.myblock.imageSource" />';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
@@ -26,7 +26,7 @@ class Tests_Directives_WpBind extends WP_UnitTestCase {
 		process_wp_bind( $tags, $context );
 
 		$this->assertSame(
-			'<img src="./wordpress.png" data-wp-bind.src="context.myblock.imageSource" />',
+			'<img src="./wordpress.png" data-wp-bind--src="context.myblock.imageSource" />',
 			$tags->get_updated_html()
 		);
 		$this->assertSame( './wordpress.png', $tags->get_attribute( 'src' ) );

--- a/phpunit/directives/attributes/wp-class.php
+++ b/phpunit/directives/attributes/wp-class.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/../../../src/directives/wp-html.php';
  */
 class Tests_Directives_WpClass extends WP_UnitTestCase {
 	public function test_directive_adds_class() {
-		$markup = '<div data-wp-class.red="context.myblock.isRed" class="blue">Test</div>';
+		$markup = '<div data-wp-class--red="context.myblock.isRed" class="blue">Test</div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
@@ -26,7 +26,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 		process_wp_class( $tags, $context );
 
 		$this->assertSame(
-			'<div data-wp-class.red="context.myblock.isRed" class="blue red">Test</div>',
+			'<div data-wp-class--red="context.myblock.isRed" class="blue red">Test</div>',
 			$tags->get_updated_html()
 		);
 		$this->assertStringContainsString( 'red', $tags->get_attribute( 'class' ) );
@@ -34,7 +34,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 	}
 
 	public function test_directive_removes_class() {
-		$markup = '<div data-wp-class.blue="context.myblock.isBlue" class="red blue">Test</div>';
+		$markup = '<div data-wp-class--blue="context.myblock.isBlue" class="red blue">Test</div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
@@ -43,7 +43,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 		process_wp_class( $tags, $context );
 
 		$this->assertSame(
-			'<div data-wp-class.blue="context.myblock.isBlue" class="red">Test</div>',
+			'<div data-wp-class--blue="context.myblock.isBlue" class="red">Test</div>',
 			$tags->get_updated_html()
 		);
 		$this->assertStringNotContainsString( 'blue', $tags->get_attribute( 'class' ) );
@@ -51,7 +51,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 	}
 
 	public function test_directive_removes_empty_class_attribute() {
-		$markup = '<div data-wp-class.blue="context.myblock.isBlue" class="blue">Test</div>';
+		$markup = '<div data-wp-class--blue="context.myblock.isBlue" class="blue">Test</div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
@@ -61,7 +61,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 
 		$this->assertSame(
 			// WP_HTML_Tag_Processor has a TODO note to prune whitespace after classname removal.
-			'<div data-wp-class.blue="context.myblock.isBlue" >Test</div>',
+			'<div data-wp-class--blue="context.myblock.isBlue" >Test</div>',
 			$tags->get_updated_html()
 		);
 		$this->assertNull( $tags->get_attribute( 'class' ) );
@@ -69,7 +69,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 	}
 
 	public function test_directive_does_not_remove_non_existant_class() {
-		$markup = '<div data-wp-class.blue="context.myblock.isBlue" class="green red">Test</div>';
+		$markup = '<div data-wp-class--blue="context.myblock.isBlue" class="green red">Test</div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
@@ -78,7 +78,7 @@ class Tests_Directives_WpClass extends WP_UnitTestCase {
 		process_wp_class( $tags, $context );
 
 		$this->assertSame(
-			'<div data-wp-class.blue="context.myblock.isBlue" class="green red">Test</div>',
+			'<div data-wp-class--blue="context.myblock.isBlue" class="green red">Test</div>',
 			$tags->get_updated_html()
 		);
 		$this->assertSame( 'green red', $tags->get_attribute( 'class' ) );

--- a/phpunit/directives/attributes/wp-style.php
+++ b/phpunit/directives/attributes/wp-style.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/../../../src/directives/wp-html.php';
  */
 class Tests_Directives_WpStyle extends WP_UnitTestCase {
 	public function test_directive_adds_style() {
-		$markup = '<div data-wp-style.color="context.myblock.color" style="background: blue;">Test</div>';
+		$markup = '<div data-wp-style--color="context.myblock.color" style="background: blue;">Test</div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		$tags->next_tag();
 
@@ -26,7 +26,7 @@ class Tests_Directives_WpStyle extends WP_UnitTestCase {
 		process_wp_style( $tags, $context );
 
 		$this->assertSame(
-			'<div data-wp-style.color="context.myblock.color" style="background: blue;color: green;">Test</div>',
+			'<div data-wp-style--color="context.myblock.color" style="background: blue;color: green;">Test</div>',
 			$tags->get_updated_html()
 		);
 		$this->assertStringContainsString( 'color: green;', $tags->get_attribute( 'style' ) );

--- a/phpunit/directives/wp-process-directives.php
+++ b/phpunit/directives/wp-process-directives.php
@@ -48,7 +48,7 @@ class Tests_Directives_WpProcessDirectives extends WP_UnitTestCase {
 		wp_process_directives( $tags, 'foo-', $directives );
 	}
 
-	public function test_directives_with_dot_processed_correctly() {
+	public function test_directives_with_double_hyphen_processed_correctly() {
 		$test_helper = $this->createMock( Helper_Class::class );
 		$test_helper->expects( $this->atLeastOnce() )
 					->method( 'process_foo_test' );
@@ -57,7 +57,7 @@ class Tests_Directives_WpProcessDirectives extends WP_UnitTestCase {
 			'foo-test' => array( $test_helper, 'process_foo_test' ),
 		);
 
-		$markup = '<div foo-test.value="abc"></div>';
+		$markup = '<div foo-test--value="abc"></div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
 		wp_process_directives( $tags, 'foo-', $directives );
 	}

--- a/src/directives/attributes/wp-bind.php
+++ b/src/directives/attributes/wp-bind.php
@@ -19,10 +19,10 @@ function process_wp_bind( $tags, $context ) {
 		return;
 	}
 
-	$prefixed_attributes = $tags->get_attribute_names_with_prefix( 'data-wp-bind.' );
+	$prefixed_attributes = $tags->get_attribute_names_with_prefix( 'data-wp-bind--' );
 
 	foreach ( $prefixed_attributes as $attr ) {
-		list( , $bound_attr ) = explode( '.', $attr );
+		list( , $bound_attr ) = explode( '--', $attr );
 		if ( empty( $bound_attr ) ) {
 			continue;
 		}

--- a/src/directives/attributes/wp-class.php
+++ b/src/directives/attributes/wp-class.php
@@ -19,10 +19,10 @@ function process_wp_class( $tags, $context ) {
 		return;
 	}
 
-	$prefixed_attributes = $tags->get_attribute_names_with_prefix( 'data-wp-class.' );
+	$prefixed_attributes = $tags->get_attribute_names_with_prefix( 'data-wp-class--' );
 
 	foreach ( $prefixed_attributes as $attr ) {
-		list( , $class_name ) = explode( '.', $attr );
+		list( , $class_name ) = explode( '--', $attr );
 		if ( empty( $class_name ) ) {
 			continue;
 		}

--- a/src/directives/attributes/wp-style.php
+++ b/src/directives/attributes/wp-style.php
@@ -19,10 +19,10 @@ function process_wp_style( $tags, $context ) {
 		return;
 	}
 
-	$prefixed_attributes = $tags->get_attribute_names_with_prefix( 'data-wp-style.' );
+	$prefixed_attributes = $tags->get_attribute_names_with_prefix( 'data-wp-style--' );
 
 	foreach ( $prefixed_attributes as $attr ) {
-		list( , $style_name ) = explode( '.', $attr );
+		list( , $style_name ) = explode( '--', $attr );
 		if ( empty( $style_name ) ) {
 			continue;
 		}

--- a/src/directives/wp-process-directives.php
+++ b/src/directives/wp-process-directives.php
@@ -46,7 +46,7 @@ function wp_process_directives( $tags, $prefix, $directives ) {
 			// Helper that removes the part after the dot before looking
 			// for the directive processor inside `$attribute_directives`.
 			$get_directive_type = function ( $attr ) {
-				return strtok( $attr, '.' );
+				return explode( '--', $attr )[0];
 			};
 
 			$attributes = $tags->get_attribute_names_with_prefix( $prefix );

--- a/src/directives/wp-process-directives.php
+++ b/src/directives/wp-process-directives.php
@@ -43,8 +43,8 @@ function wp_process_directives( $tags, $prefix, $directives ) {
 				}
 			}
 		} else {
-			// Helper that removes the part after the dot before looking
-			// for the directive processor inside `$attribute_directives`.
+			// Helper that removes the part after the double hyphen before looking for
+			// the directive processor inside `$attribute_directives`.
 			$get_directive_type = function ( $attr ) {
 				return explode( '--', $attr )[0];
 			};

--- a/src/runtime/constants.js
+++ b/src/runtime/constants.js
@@ -1,2 +1,2 @@
 export const csnMetaTagItemprop = 'wp-client-side-navigation';
-export const directivePrefix = 'data-wp-';
+export const directivePrefix = 'wp';

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -44,7 +44,7 @@ export default () => {
 		{ priority: 5 }
 	);
 
-	// data-wp-effect.[name]
+	// data-wp-effect--[name]
 	directive('effect', ({ directives: { effect }, context, evaluate }) => {
 		const contextValue = useContext(context);
 		Object.values(effect).forEach((path) => {
@@ -54,7 +54,7 @@ export default () => {
 		});
 	});
 
-	// data-wp-on.[event]
+	// data-wp-on--[event]
 	directive('on', ({ directives: { on }, element, evaluate, context }) => {
 		const contextValue = useContext(context);
 		Object.entries(on).forEach(([name, path]) => {
@@ -64,7 +64,7 @@ export default () => {
 		});
 	});
 
-	// data-wp-class.[classname]
+	// data-wp-class--[classname]
 	directive(
 		'class',
 		({ directives: { class: className }, element, evaluate, context }) => {
@@ -104,7 +104,7 @@ export default () => {
 		}
 	);
 
-	// data-wp-bind.[attribute]
+	// data-wp-bind--[attribute]
 	directive(
 		'bind',
 		({ directives: { bind }, element, context, evaluate }) => {

--- a/src/runtime/router.js
+++ b/src/runtime/router.js
@@ -162,7 +162,7 @@ export const init = async () => {
 		pages.set(cleanUrl(window.location), Promise.resolve({ body, head }));
 	} else {
 		document
-			.querySelectorAll(`[${directivePrefix}island]`)
+			.querySelectorAll(`[data-${directivePrefix}-island]`)
 			.forEach((node) => {
 				if (!hydratedIslands.has(node)) {
 					const fragment = createRootFragment(node.parentNode, node);

--- a/src/runtime/router.js
+++ b/src/runtime/router.js
@@ -162,7 +162,7 @@ export const init = async () => {
 		pages.set(cleanUrl(window.location), Promise.resolve({ body, head }));
 	} else {
 		document
-			.querySelectorAll(`[data-${directivePrefix}-island]`)
+			.querySelectorAll(`[data-${directivePrefix}-interactive]`)
 			.forEach((node) => {
 				if (!hydratedIslands.has(node)) {
 					const fragment = createRootFragment(node.parentNode, node);

--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -1,12 +1,13 @@
 import { h } from 'preact';
 import { directivePrefix as p } from './constants';
 
-const ignoreAttr = `${p}ignore`;
-const islandAttr = `${p}island`;
+const ignoreAttr = `data-${p}-ignore`;
+const islandAttr = `data-${p}-island`;
+const fullPrefix = `data-${p}-`;
 
 // Regular expression for directive parsing.
 const directiveParser = new RegExp(
-	`^${p}` + // ${p} must be a prefix string, like 'wp'.
+	`^data-${p}-` + // ${p} must be a prefix string, like 'wp'.
 		// Match alphanumeric characters including hyphen-separated
 		// segments. It excludes underscore intentionally to prevent confusion.
 		// E.g., "custom-directive".
@@ -51,7 +52,10 @@ export function toVdom(root) {
 
 		for (let i = 0; i < attributes.length; i++) {
 			const n = attributes[i].name;
-			if (n[p.length] && n.slice(0, p.length) === p) {
+			if (
+				n[fullPrefix.length] &&
+				n.slice(0, fullPrefix.length) === fullPrefix
+			) {
 				if (n === ignoreAttr) {
 					ignore = true;
 				} else if (n === islandAttr) {

--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { directivePrefix as p } from './constants';
 
 const ignoreAttr = `data-${p}-ignore`;
-const islandAttr = `data-${p}-island`;
+const islandAttr = `data-${p}-interactive`;
 const fullPrefix = `data-${p}-`;
 
 // Regular expression for directive parsing.

--- a/src/runtime/vdom.js
+++ b/src/runtime/vdom.js
@@ -3,7 +3,20 @@ import { directivePrefix as p } from './constants';
 
 const ignoreAttr = `${p}ignore`;
 const islandAttr = `${p}island`;
-const directiveParser = new RegExp(`${p}([^.]+)\.?(.*)$`);
+
+// Regular expression for directive parsing.
+const directiveParser = new RegExp(
+	`^${p}` + // ${p} must be a prefix string, like 'wp'.
+		// Match alphanumeric characters including hyphen-separated
+		// segments. It excludes underscore intentionally to prevent confusion.
+		// E.g., "custom-directive".
+		'([a-z0-9]+(?:-[a-z0-9]+)*)' +
+		// (Optional) Match '--' followed by any alphanumeric charachters. It
+		// excludes underscore intentionally to prevent confusion, but it can
+		// contain multiple hyphens. E.g., "--custom-prefix--with-more-info".
+		'(?:--([a-z0-9][a-z0-9-]+))?$',
+	'i' // Case insensitive.
+);
 
 export const hydratedIslands = new WeakSet();
 

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -215,10 +215,10 @@ function wp_directives_mark_interactive_blocks( $block_content, $block, $instanc
 		return $block_content;
 	}
 
-	// Add the `data-wp-island` attribute if it's interactive.
+	// Add the `data-wp-interactive` attribute if it's interactive.
 	$w = new WP_HTML_Tag_Processor( $block_content );
 	$w->next_tag();
-	$w->set_attribute( 'data-wp-island', '' );
+	$w->set_attribute( 'data-wp-interactive', '' );
 
 	return (string) $w;
 }


### PR DESCRIPTION
## What

1. I've renamed the directive syntax from `data-wp-on.click` to `data-wp-on--click`.

   - Fixes https://github.com/WordPress/block-interactivity-experiments/issues/132.

2. I've renamed the `data-wp-island` directive to `data-wp-interactive`.

   - Fixes https://github.com/WordPress/block-interactivity-experiments/issues/238

## Why

1. Because JSX doesn't support attributes with dots in them.
2. Because the term _island_ has no meaning in WordPress, and we don't intend to embrace it.

## How

1. I just renamed everything, including the regular expression.

   I also added an explanation of the expression and made sure that it remains valid HTML by disallowing anything other than alphanumeric characters and hyphens. I purposely disallowed underscores to prevent confusion with hyphens.

   I also renamed the prefix constant to hardcode `data-` and ensure that it always generates valid HTML.

2. I just renamed `data-wp-island` to `data-wp-interactive`.
