### PR TITLE
Ensure we push the commit that bumps the version to origin branch in `release-plugin` workflow

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -42,7 +42,7 @@ jobs:
               run: |
                   git add wp-directives.php package.json package-lock.json
                   git commit -m "Bump plugin version to ${{ steps.get_version.outputs.new_version }}"
-                  git push
+                  git push --set-upstream origin main-wp-directives-plugin
                   echo "version_bump_commit=$(git rev-parse --verify --short HEAD)" >> $GITHUB_OUTPUT
 
     build:


### PR DESCRIPTION
### What?

Change the GitHub workflow to release the plugin to ensure it includes the commit that bumps the version.

### Why?

At this moment, if you check [the latest release](https://github.com/WordPress/block-interactivity-experiments/releases/tag/0.1.25) for example, the plugin is built properly but it doesn't include the commit that bumps the version. This means that, although all the latest changes are applied, in the `wp-directives.php` file the version is lower than expected (`0.1.24` vs `0.1.25`).

### How?

To be honest, I am not sure if this solves the issue. But I don't know how to test GitHub actions 😄 

If we are not able to solve this, we can always update the artifact manually and wait until we migrate the repo to Gutenberg. Happy to hear your thoughts.