### PR TITLE
Experiment: Add view transitions API directive

### DIFF
--- a/e2e/page-2/store.js
+++ b/e2e/page-2/store.js
@@ -10,7 +10,7 @@ store({
 			state.newValue = !state.newValue;
 		},
 		replaceWithPage3: () => {
-			navigate('/csn-page-3.html', { replace: true });
+			navigate('/csn-page-3.html', true, { replace: true });
 		},
 	},
 });

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -80,10 +80,6 @@ export default () => {
 							navigation: {
 								addTransition: ({ ref, state }) => {
 									// Reset the previous element transition
-									console.log(
-										state.core.navigation
-											.viewTransitionElement
-									);
 									if (
 										state.core.navigation
 											.viewTransitionElement
@@ -92,23 +88,8 @@ export default () => {
 											'';
 
 									// Get new key
-									let linkKey = '';
-									if (
-										ref.getAttribute('data-wp-transition')
-									) {
-										linkKey =
-											ref.getAttribute(
-												'data-wp-transition'
-											);
-									} else if (
-										ref.getAttribute(
-											'[data-wp-transition--main]'
-										)
-									) {
-										linkKey = ref.getAttribute(
-											'data-wp-transition--main'
-										);
-									}
+									const linkKey =
+										ref.getAttribute('data-wp-transition');
 
 									ref.style.viewTransitionName = linkKey;
 									state.core.navigation.viewTransitionKey =
@@ -122,12 +103,12 @@ export default () => {
 				});
 
 			const contextValue = useContext(context);
-			Object.entries(transition).forEach(([option, key]) => {
+			Object.values(transition).forEach((key) => {
 				useLayoutEffect(() => {
 					// If there is no Key, set it to the main option if exists.
 					if (
 						!state.core.navigation.viewTransitionKey &&
-						option === 'main'
+						element.props['data-wp-transition-main']
 					) {
 						state.core.navigation.viewTransitionKey = key;
 						state.core.navigation.viewTransitionElement =

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -167,21 +167,10 @@ export default () => {
 						link.viewTransitionsAPI
 					) {
 						document.startViewTransition(async () => {
-							await navigate(href);
+							await navigate(href, link?.scroll);
 						});
 					} else {
-						await navigate(href);
-					}
-
-					// Update the scroll, depending on the option. True by default.
-					if (link?.scroll === 'smooth') {
-						window.scrollTo({
-							top: 0,
-							left: 0,
-							behavior: 'smooth',
-						});
-					} else if (link?.scroll !== false) {
-						window.scrollTo(0, 0);
+						await navigate(href, link?.scroll);
 					}
 				};
 			}

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -128,7 +128,6 @@ export default () => {
 					} else {
 						element.ref.current.style.viewTransitionName = '';
 					}
-					// console.log(element.ref.current.style);
 
 					return evaluate(key, { context: contextValue });
 				});

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -88,12 +88,14 @@ export default () => {
 											'';
 
 									// Get new key
-									const linkKey =
+									const transitionKey =
+										'item-' +
 										ref.getAttribute('data-wp-transition');
 
-									ref.style.viewTransitionName = linkKey;
+									ref.style.viewTransitionName =
+										transitionKey;
 									state.core.navigation.viewTransitionKey =
-										linkKey;
+										transitionKey;
 									state.core.navigation.viewTransitionElement =
 										ref;
 								},
@@ -104,23 +106,30 @@ export default () => {
 
 			const contextValue = useContext(context);
 			Object.values(transition).forEach((key) => {
+				const transitionKey = 'item-' + key;
 				useLayoutEffect(() => {
 					// If there is no Key, set it to the main option if exists.
 					if (
 						!state.core.navigation.viewTransitionKey &&
 						element.props['data-wp-transition-main']
 					) {
-						state.core.navigation.viewTransitionKey = key;
+						state.core.navigation.viewTransitionKey = transitionKey;
 						state.core.navigation.viewTransitionElement =
 							element.ref.current;
 					}
 
 					// If the key matches, add transition. If not, remove it.
-					if (state.core.navigation.viewTransitionKey === key) {
-						element.ref.current.style.viewTransitionName = key;
+					if (
+						state.core.navigation.viewTransitionKey ===
+						transitionKey
+					) {
+						element.ref.current.style.viewTransitionName =
+							transitionKey;
 					} else {
 						element.ref.current.style.viewTransitionName = '';
 					}
+					// console.log(element.ref.current.style);
+
 					return evaluate(key, { context: contextValue });
 				});
 			});

--- a/src/runtime/directives.js
+++ b/src/runtime/directives.js
@@ -1,9 +1,8 @@
-import { useContext, useMemo, useEffect, useLayoutEffect } from 'preact/hooks';
+import { useContext, useMemo, useEffect } from 'preact/hooks';
 import { deepSignal, peek } from 'deepsignal';
 import { useSignalEffect } from './utils';
 import { directive } from './hooks';
 import { prefetch, navigate, canDoClientSideNavigation } from './router';
-import { store as addStore } from './store';
 
 // Check if current page can do client-side navigation.
 const clientSideNavigation = canDoClientSideNavigation(document.head);
@@ -54,86 +53,6 @@ export default () => {
 			});
 		});
 	});
-
-	// data-wp-view-transitions-key--[option]
-	directive(
-		'transition',
-		({
-			directives: { transition },
-			context,
-			evaluate,
-			element,
-			store: { state, actions },
-		}) => {
-			if (!actions?.core?.navigation?.addTransition)
-				addStore({
-					state: {
-						core: {
-							navigation: {
-								viewTransitionKey: null,
-								viewTransitionElement: null,
-							},
-						},
-					},
-					actions: {
-						core: {
-							navigation: {
-								addTransition: ({ ref, state }) => {
-									// Reset the previous element transition
-									if (
-										state.core.navigation
-											.viewTransitionElement
-									)
-										state.core.navigation.viewTransitionElement.style.viewTransitionName =
-											'';
-
-									// Get new key
-									const transitionKey =
-										'item-' +
-										ref.getAttribute('data-wp-transition');
-
-									ref.style.viewTransitionName =
-										transitionKey;
-									state.core.navigation.viewTransitionKey =
-										transitionKey;
-									state.core.navigation.viewTransitionElement =
-										ref;
-								},
-							},
-						},
-					},
-				});
-
-			const contextValue = useContext(context);
-			Object.values(transition).forEach((key) => {
-				const transitionKey = 'item-' + key;
-				useLayoutEffect(() => {
-					// If there is no Key, set it to the main option if exists.
-					if (
-						!state.core.navigation.viewTransitionKey &&
-						element.props['data-wp-transition-main']
-					) {
-						state.core.navigation.viewTransitionKey = transitionKey;
-						state.core.navigation.viewTransitionElement =
-							element.ref.current;
-					}
-
-					// If the key matches, add transition. If not, remove it.
-					if (
-						state.core.navigation.viewTransitionKey ===
-						transitionKey
-					) {
-						element.ref.current.style.viewTransitionName =
-							transitionKey;
-					} else {
-						element.ref.current.style.viewTransitionName = '';
-					}
-
-					return evaluate(key, { context: contextValue });
-				});
-			});
-		}
-	);
 
 	// data-wp-on--[event]
 	directive('on', ({ directives: { on }, element, evaluate, context }) => {

--- a/src/runtime/hooks.js
+++ b/src/runtime/hooks.js
@@ -130,6 +130,8 @@ const RecursivePriorityLevel = ({
 const old = options.vnode;
 options.vnode = (vnode) => {
 	if (vnode.props.__directives) {
+		if (vnode.props['data-wp-key'])
+			vnode.props.key = vnode.props['data-wp-key'];
 		const props = vnode.props;
 		const directives = props.__directives;
 		delete props.__directives;

--- a/src/runtime/hooks.js
+++ b/src/runtime/hooks.js
@@ -109,7 +109,14 @@ const RecursivePriorityLevel = ({
 		);
 
 	const props = { ...originalProps, children };
-	const directiveArgs = { directives, props, element, context, evaluate };
+	const directiveArgs = {
+		directives,
+		props,
+		element,
+		context,
+		evaluate,
+		store,
+	};
 
 	for (const d in directives) {
 		const wrapper = directiveMap[d]?.(directiveArgs);

--- a/src/runtime/index.js
+++ b/src/runtime/index.js
@@ -2,6 +2,8 @@ import registerDirectives from './directives';
 import { init } from './router';
 export { store } from './store';
 export { navigate } from './router';
+export { directive } from './hooks';
+export * from 'preact/hooks';
 
 /**
  * Initialize the Interactivity API.

--- a/src/runtime/router.js
+++ b/src/runtime/router.js
@@ -116,7 +116,11 @@ export const prefetch = (url) => {
 };
 
 // Navigate to a new page.
-export const navigate = async (href, { replace = false } = {}) => {
+export const navigate = async (
+	href,
+	scroll = true,
+	{ replace = false } = {}
+) => {
 	const url = cleanUrl(href);
 	prefetch(url);
 	const page = await pages.get(url);
@@ -126,6 +130,17 @@ export const navigate = async (href, { replace = false } = {}) => {
 		window.history[replace ? 'replaceState' : 'pushState']({}, '', href);
 	} else {
 		window.location.assign(href);
+	}
+
+	// Update the scroll, depending on the option. True by default.
+	if (scroll === 'smooth') {
+		window.scrollTo({
+			top: 0,
+			left: 0,
+			behavior: 'smooth',
+		});
+	} else if (scroll !== false) {
+		window.scrollTo(0, 0);
 	}
 };
 

--- a/src/runtime/store.js
+++ b/src/runtime/store.js
@@ -19,7 +19,7 @@ export const deepMerge = (target, source) => {
 const getSerializedState = () => {
 	// TODO: change the store tag ID for a better one.
 	const storeTag = document.querySelector(
-		`script[type="application/json"]#store`
+		`script[type="application/json"]#wp-interactivity-store-data`
 	);
 	if (!storeTag) return {};
 	try {

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -128,10 +128,10 @@ function wp_directives_add_wp_link_attribute( $block_content ) {
 			) {
 				$w->set_attribute(
 					'data-wp-link',
-					'{ "prefetch": true, "scroll": false }'
+					'{ "prefetch": true, "viewTransitionsAPI": true, "scroll": false }'
 				);
 			} else {
-				$w->set_attribute( 'data-wp-link', '{ "prefetch": true }' );
+				$w->set_attribute( 'data-wp-link', '{ "prefetch": true, "viewTransitionsAPI": true, "scroll": false }' );
 			}
 		}
 	}

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:       wp-directives
- * Version:           0.1.26
+ * Version:           0.1.27
  * Requires at least: 6.0
  * Requires PHP:      5.6
  * Author:            Gutenberg Team
@@ -37,18 +37,18 @@ if ( ! is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
 	return;
 }
 
-require_once __DIR__ . '/src/directives/wp-html.php';
+// require_once __DIR__ . '/src/directives/wp-html.php';
 
-require_once __DIR__ . '/src/directives/class-wp-directive-context.php';
-require_once __DIR__ . '/src/directives/class-wp-directive-store.php';
-require_once __DIR__ . '/src/directives/wp-process-directives.php';
+// require_once __DIR__ . '/src/directives/class-wp-directive-context.php';
+// require_once __DIR__ . '/src/directives/class-wp-directive-store.php';
+// require_once __DIR__ . '/src/directives/wp-process-directives.php';
 
-require_once __DIR__ . '/src/directives/attributes/wp-bind.php';
-require_once __DIR__ . '/src/directives/attributes/wp-context.php';
-require_once __DIR__ . '/src/directives/attributes/wp-class.php';
-require_once __DIR__ . '/src/directives/attributes/wp-html.php';
-require_once __DIR__ . '/src/directives/attributes/wp-style.php';
-require_once __DIR__ . '/src/directives/attributes/wp-text.php';
+// require_once __DIR__ . '/src/directives/attributes/wp-bind.php';
+// require_once __DIR__ . '/src/directives/attributes/wp-context.php';
+// require_once __DIR__ . '/src/directives/attributes/wp-class.php';
+// require_once __DIR__ . '/src/directives/attributes/wp-html.php';
+// require_once __DIR__ . '/src/directives/attributes/wp-style.php';
+// require_once __DIR__ . '/src/directives/attributes/wp-text.php';
 
 /**
  * Load includes.
@@ -269,13 +269,13 @@ function process_directives_in_block( $block_content ) {
 	$tags = wp_process_directives( $tags, 'data-wp-', $directives );
 	return $tags->get_updated_html();
 }
-add_filter(
-	'render_block',
-	'process_directives_in_block',
-	10,
-	1
-);
+// add_filter(
+// 	'render_block',
+// 	'process_directives_in_block',
+// 	10,
+// 	1
+// );
 
 // TODO: check if priority 9 is enough.
 // TODO: check if `wp_footer` is the most appropriate hook.
-add_action( 'wp_footer', array( 'WP_Directive_Store', 'render' ), 9 );
+// add_action( 'wp_footer', array( 'WP_Directive_Store', 'render' ), 9 );

--- a/wp-directives.php
+++ b/wp-directives.php
@@ -131,7 +131,7 @@ function wp_directives_add_wp_link_attribute( $block_content ) {
 					'{ "prefetch": true, "viewTransitionsAPI": true, "scroll": false }'
 				);
 			} else {
-				$w->set_attribute( 'data-wp-link', '{ "prefetch": true, "viewTransitionsAPI": true, "scroll": false }' );
+				$w->set_attribute( 'data-wp-link', '{ "prefetch": true, "viewTransitionsAPI": true }' );
 			}
 		}
 	}


### PR DESCRIPTION
I started exploring the possibility of creating a directive for the View Transitions API. Here you have a video with the explanation:

https://www.loom.com/share/39631b65aebf42b386f0fee14e0b3f58?sid=fd5f26d5-1105-43ab-87a0-d66467e6ebff

This is the [branch](https://github.com/WordPress/wp-movies-demo/tree/view-transitions-support) of the movies repo.

Basically, what I did:

* Support a new property `viewTransitionsAPI` in the `wp-link` directive. If it is set to true, the viewTransitionsAPI is enabled while navigating. This already enables all the transitions that can be achieved only with CSS.
* For more complex uses cases, I created a `data-wp-transition` directive:
    * It creates a global action and global state to be able to create transitions that need a unique id. The transitions are added dynamically with JS. When the action is called, it updates the global state and add the transition to the current element. In the new page, we have a `init` function that checks if the key defined in the directive matches the global state. If so, it adds the transition dynamically.

There are some aspects to review, although it is already working more or less fine for the movies:
* There seems to be a problem with the `backdrop-filter`.
* Adding the global action to the same element using the `wp-link` directive seems to cause a conflict.
* We have to rethink the naming and structure of the new directives.